### PR TITLE
feat(platform): add onboarding tools, split CI workflows, and refine docs

### DIFF
--- a/docs/user-guide/00-platform-overview.ja.md
+++ b/docs/user-guide/00-platform-overview.ja.md
@@ -10,6 +10,8 @@ tags:
   - git-hooks
 ---
 
+<!-- markdownlint-disable line-length -->
+
 ## 🏗️ ci-platform とは
 
 `ci-platform` は、**複数の OSS リポジトリにわたる CI/CD を統制・管理するための基盤**です。
@@ -62,27 +64,19 @@ GitHub Actions の Composite Action と Reusable Workflow を SHA 固定で参�
 
 ### Composite Action (`aglabo/ci-platform`)
 
-<!-- markdownlint-disable line-length MD060 -->
-
 | コンポーネント         | 役割                                                                                                     |
 | ---------------------- | -------------------------------------------------------------------------------------------------------- |
 | `validate-environment` | **CI 冒頭に置くゲート**。ランナー OS・パーミッション・ツールを検証し、ポリシー違反を即座にブロックします |
 
-<!-- markdownlint-enable line-length MD060 -->
-
 Composite Action は `steps:` から参照します。ジョブ内で fail-fast として機能します。
 
 ### Reusable Workflow (`aglabo/.github`)
-
-<!-- markdownlint-disable line-length -->
 
 | コンポーネント | 役割                                  | 参照パス (`@r1.1.2`)                                             |
 | -------------- | ------------------------------------- | ---------------------------------------------------------------- |
 | actionlint     | GitHub Actions ワークフローの構文検証 | `aglabo/.github/.github/workflows/ci-common-lint-actionlint.yml` |
 | ghalint        | GitHub Actions のポリシー違反検出     | `aglabo/.github/.github/workflows/ci-common-lint-ghalint.yml`    |
 | gitleaks       | リポジトリ全体の機密情報スキャン      | `aglabo/.github/.github/workflows/ci-common-scan-gitleaks.yml`   |
-
-<!-- markdownlint-enable line-length -->
 
 Reusable Workflow は `jobs:` から参照します。複数ジョブ・複数リポジトリにわたるポリシーを強制します。
 


### PR DESCRIPTION
<!--markdownlint-disable line-length -->

## Overview

**Summary**
Add PowerShell onboarding installers, split CI workflows, separate markdownlint config, and refine user-guide docs.

**Background / Motivation**
The CI platform lacked a unified Windows onboarding experience, and a single `ci-scan-all.yml` workflow mixed secrets scanning with GHA quality checks. markdownlint execution config was embedded rather than isolated, and user-guide docs needed clarity improvements for pinned versions and permission flows.

---

## Changes

- Added `scripts/install-dev-tools.ps1` and `scripts/install-doc-tools.ps1` as PowerShell-based onboarding installers backed by a refactored `AgInstaller.ps1` library (winget / scoop / pnpm batch installs)
- Renamed `ci-scan-all.yml` → `ci-scan-secrets.yml` (gitleaks only) and introduced `ci-workflows-qa.yml` for actionlint + ghalint validation; added `lint:gha` npm scripts and `lint-actionlint.sh` wrapper
- Extracted markdownlint-cli2 execution config into `configs/.markdownlint-cli2.yaml`; added `no-duplicate-heading` rule to `configs/.markdownlint.yaml`
- Refined `docs/user-guide/00-platform-overview.ja.md` and `12-basic-scenarios.ja.md` for clarity, pinned version examples, and permission flow descriptions
- Updated `CLAUDE.md` workflow name references to match renamed CI files

---

## Change Type (optional)

Select all that apply:

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [x] Configuration
- [x] CI/CD
- [ ] Other

---

## Related Issues

> Related #18

---

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [x] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

---

## Additional Notes
