### PR TITLE
fix(actions): validate-environment のコマンドインジェクション脆弱性を修正

### DIFF
--- a/.github/actions/validate-environment/action.yml
+++ b/.github/actions/validate-environment/action.yml
@@ -107,17 +107,18 @@ runs:
       # curl availability is checked inside validate-permissions.sh before API calls.
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+        ACTIONS_TYPE: ${{ inputs.actions-type }}
       run: |
         set -euo pipefail
-        bash "${GITHUB_ACTION_PATH}/scripts/validate-permissions.sh" "${{ inputs.actions-type }}"
+        bash "${GITHUB_ACTION_PATH}/scripts/validate-permissions.sh" "$ACTIONS_TYPE"
       # Outputs: status, message (written to $GITHUB_OUTPUT by script)
 
     - name: "Validate required applications"
       id: validate-apps
       shell: bash
+      env:
+        ADDITIONAL_APPS: ${{ inputs.additional-apps }}
       run: |
         set -euo pipefail
-        bash "${GITHUB_ACTION_PATH}/scripts/validate-apps.sh" <<'APPS_EOF'
-        ${{ inputs.additional-apps }}
-        APPS_EOF
+        printf '%s\n' "$ADDITIONAL_APPS" | bash "${GITHUB_ACTION_PATH}/scripts/validate-apps.sh"
       # Outputs: status, message

--- a/.github/actions/validate-environment/scripts/__tests__/validate-apps/functional/initialize-apps-list.functional.spec.sh
+++ b/.github/actions/validate-environment/scripts/__tests__/validate-apps/functional/initialize-apps-list.functional.spec.sh
@@ -271,6 +271,90 @@ Describe 'initialize_apps_list()'
     End
   End
 
+  Context 'security: shell injection via stdin'
+    It 'rejects semicolon injection in cmd field'
+      Data
+        #|git;curl evil.com|Malicious
+      End
+      When call initialize_apps_list
+      The status should be failure
+      The stderr should include "::error::"
+      The stderr should include "metacharacters"
+    End
+
+    It 'rejects backtick injection in cmd field'
+      Data
+        #|`curl evil.com`|Malicious
+      End
+      When call initialize_apps_list
+      The status should be failure
+      The stderr should include "::error::"
+      The stderr should include "metacharacters"
+    End
+
+    It 'rejects dollar-paren injection in cmd field'
+      Data
+        #|$(curl evil.com)|Malicious
+      End
+      When call initialize_apps_list
+      The status should be failure
+      The stderr should include "::error::"
+      The stderr should include "metacharacters"
+    End
+
+    It 'rejects pipe injection in cmd field (treated as extra field)'
+      Data
+        #|git|bash|evil-cmd|extra|field
+      End
+      When call initialize_apps_list
+      The status should be failure
+      The stderr should include "::error::"
+      The stderr should include "expected 2 or 4 pipe-delimited fields"
+    End
+
+    It 'rejects relative path injection in cmd field'
+      Data
+        #|../../../bin/sh|Malicious
+      End
+      When call initialize_apps_list
+      The status should be failure
+      The stderr should include "::error::"
+      The stderr should include "relative path"
+    End
+
+    It 'rejects newline injection in cmd field'
+      Data
+        #|git
+        #|bash evil.com|Malicious
+      End
+      When call initialize_apps_list
+      The status should be failure
+      The stderr should include "::error::"
+    End
+
+    It 'rejects ampersand injection in cmd field'
+      Data
+        #|git&evil|Malicious
+      End
+      When call initialize_apps_list
+      The status should be failure
+      The stderr should include "::error::"
+      The stderr should include "metacharacters"
+    End
+
+    It 'does not execute injected command (side-effect check)'
+      _injection_marker_file=$(mktemp)
+      rm -f "$_injection_marker_file"
+      Data
+        #|git;touch ${_injection_marker_file}|Malicious
+      End
+      When call initialize_apps_list
+      The status should be failure
+      The stderr should include "::error::"
+      The path "${_injection_marker_file}" should not be exist
+    End
+  End
+
   Context 'app count limit (MAX_APPS = 30)'
     call_with_n_defaults() {
       local n=$1

--- a/.github/actions/validate-environment/scripts/validate-apps.sh
+++ b/.github/actions/validate-environment/scripts/validate-apps.sh
@@ -299,6 +299,7 @@ get_app_version() {
 # @note No output. Caller uses exit code to construct error messages.
 # Rejected: control characters, relative paths (./ ../), shell metacharacters (;|&$`()*?{} space)
 # Allowed: / - _ (for absolute paths like /usr/bin/gh)
+# Note: comma (,) is intentionally excluded from rejection — it has no shell injection risk in bash
 is_safe_command() {
   local cmd="$1"
   [[ "$cmd" =~ $'\n'|$'\r'|$'\t' ]] && return 1


### PR DESCRIPTION
<!-- markdownlint-disable line-length -->

## Overview

**Summary**
Fix command injection vulnerability in validate-environment by passing inputs via env vars instead of direct shell expansion.

**Background / Motivation**
`validate-environment` Composite Action において、`inputs.actions-type` と `inputs.additional-apps` をワークフロー式 (`${{ inputs.* }}`) として `run` ブロックに直接展開していた。この実装では、攻撃者が細工した入力値によってシェルコマンドインジェクションが発生しうる脆弱性が存在した。

`env:` セクションで環境変数として受け取る方式に変更することで脆弱性を修正し、セキュリティテストを追加して修正を検証する。

---

## Changes

- `.github/actions/validate-environment/action.yml`: `inputs.actions-type` / `inputs.additional-apps` を `env:` セクション経由で環境変数として渡すよう変更し、シェル直接展開を廃止
- `.github/actions/validate-environment/scripts/validate-apps.sh`: `is_safe_command` のコメントにカンマ意図的除外の旨を追記
- `.github/actions/validate-environment/scripts/__tests__/validate-apps/functional/initialize-apps-list.functional.spec.sh`: shell injection 攻撃パターン 8件のセキュリティテストを新規追加

---

## Change Type (optional)

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

---

## Related Issues

Closes #36

---

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

---

## Additional Notes

Security Impact:

- 修正前: `${{ inputs.actions-type }}` をシェルの引数に直接展開していたため、`;` や改行を含む入力でコマンドインジェクションが可能だった
- 修正後: `env:` セクション経由の渡し方に統一し、word splitting・glob 展開の影響を受けない設計に変更

新規セキュリティテスト (8件):

対象攻撃パターン: `;`、バッククォート、`$()`、パイプ余剰フィールド、`../`、改行、`&`、および `touch` コマンドによる副作用チェック
