### PR TITLE
docs(setup-tool): add Deckrd design docs, fix get-filelist path normalization, and add unit tests

### DIFF
--- a/.github/actions/setup-tool/scripts/setup-directories.sh
+++ b/.github/actions/setup-tool/scripts/setup-directories.sh
@@ -38,14 +38,14 @@ set -euo pipefail
 # Create persistent bin directory in runner temp
 BIN_DIR="${RUNNER_TEMP}/bin"
 mkdir -p "${BIN_DIR}"
-echo "BIN_DIR=${BIN_DIR}" >> "${GITHUB_ENV}"
+echo "BIN_DIR=${BIN_DIR}" >>"${GITHUB_ENV}"
 echo "Installation directory: ${BIN_DIR}"
 
 # Create job-local temp directory
 TEMP_DIR=$(mktemp -d)
-echo "TEMP_DIR=${TEMP_DIR}" >> "${GITHUB_ENV}"
+echo "TEMP_DIR=${TEMP_DIR}" >>"${GITHUB_ENV}"
 echo "Temporary directory: ${TEMP_DIR}"
 
 # Add bin directory to PATH for subsequent steps
-echo "${BIN_DIR}" >> "${GITHUB_PATH}"
+echo "${BIN_DIR}" >>"${GITHUB_PATH}"
 echo "✓ Directories configured and PATH updated"

--- a/docs/.deckrd/composite-action/setup-tool/implementation/implementation.md
+++ b/docs/.deckrd/composite-action/setup-tool/implementation/implementation.md
@@ -1,0 +1,332 @@
+---
+title: "Implementation Plan: setup-tool composite action"
+based-on: specifications.md v1.3.0
+status: Draft
+---
+
+<!-- markdownlint-disable line-length -->
+
+## 1. Overview
+
+### 1.1 Purpose
+
+GitHub Actions の composite action として、指定された GitHub リポジトリのリリースから
+ツールをダウンロードし、チェックサム検証・アーカイブ展開を行い、
+ツールバイナリを実行可能な PATH に配置する。
+
+実装は関数ライブラリ式（4ファイル構成）で新規作成する。
+既存スクリプト群（`setup-directories.sh` 等）は参考実装として廃止する。
+
+主要な設計決定:
+
+- GitHub API（`api.github.com`）でアセット一覧を1回取得し、tar.gz の arch 解決と
+  checksums.txt の選択を同時に行う（`jq` は `validate-environment` で保証）
+- `repo` は `owner/repo` 形式のまま URL に直接埋め込む（分割不要）
+- checksums.txt の候補順: `checksums.txt` → `{tool-name}_{version}_checksums.txt`
+- ダウンロードした tar.gz は `${TOOL_NAME}.tar.gz` にリネームして後続処理で一貫参照
+- スクリプト間 I/F: パラメータ渡し・stdout 返却・`.` でライブラリ読み込み
+- 複数値返却規約: 1行 = 1値・空行なしで出力し、呼び出し元は `mapfile` で行単位にキャプチャする
+
+### 1.2 実装品質基準（全コミット共通）
+
+以下を全コミットに適用する規範的制約とする（DR-08）:
+
+- BDD サイクル: テストコミット後・実装コミット前に RED を確認し、実装完了条件は GREEN とする
+- `set -euo pipefail`: 全スクリプト・全ライブラリファイルの先頭に設定する（ライブラリは double-source guard の後）
+- double-source guard: 新規作成する全ライブラリファイルに付与する
+- エラー出力: `::error::<message>` を stderr に出力し、フェーズ別固定 exit code で終了する
+
+### 1.3 Reference
+
+- Prior Art: `.github-aglabo/.github/actions/scripts/`（aglabo 参考実装）
+- Prior Art: `.github/actions/setup-tool/scripts/_libs/`（既存 validation.lib.sh / common.lib.sh）
+- Specifications: `specifications/specifications.md` v1.3.0
+
+---
+
+## 2. Implementation Plan
+
+### Phase 1: ライブラリ基盤（dirs / arch）
+
+#### Commit 1: test(setup-tool/dirs): add ShellSpec tests for setup_dirs
+
+- `scripts/__tests__/dirs.unit.spec.sh` を作成
+- `setup_dirs()` の正常系: BIN_DIR・TEMP_DIR が作成されること
+- GITHUB_ENV / GITHUB_PATH への書き込み検証
+- テストが RED であることを確認
+
+#### Commit 2: feat(setup-tool/dirs): implement dirs.lib.sh
+
+- `scripts/_libs/dirs.lib.sh` を新規作成
+- `setup_dirs()`: `BIN_DIR=${RUNNER_TEMP}/bin`・`TEMP_DIR=$(mktemp -d)` を作成
+- `GITHUB_ENV` / `GITHUB_PATH` への書き込みで後続ステップに引き渡す
+- double-source guard 付き（Section 1.2 実装品質基準に準拠）
+- テストが GREEN であることを確認
+
+#### Commit 3: test(setup-tool/arch): add ShellSpec tests for detect_arch
+
+- `scripts/__tests__/arch.unit.spec.sh` を作成
+- `detect_arch()` の正常系: `X64` → `amd64`（1行目）・`x64`（2行目）を stdout 出力
+- `detect_arch()` の正常系: `ARM64` → `arm64`（1行目）を stdout 出力
+- `detect_arch()` の異常系: 未知の arch → `::error::` を stderr に出力して exit 1
+- テストが RED であることを確認
+
+#### Commit 4: feat(setup-tool/arch): implement arch.lib.sh
+
+- `scripts/_libs/arch.lib.sh` を新規作成
+- `detect_arch()`: `runner.arch` → `ARCH_CANDIDATES` を1行1値で stdout に出力
+  - `X64` → `amd64`（1行目）・`x64`（2行目）
+  - `ARM64` → `arm64`（1行目）
+  - 未知 → `::error::` を stderr に出力して exit 1
+- 呼び出し元は `mapfile -t ARCH_CANDIDATES < <(detect_arch)` でキャプチャ
+- double-source guard 付き
+- `resolve_arch()` は実装しない（`resolve_assets()` に統合）
+- テストが GREEN であることを確認
+
+---
+
+### Phase 2: ダウンロードライブラリ（download）
+
+#### Commit 5: test(setup-tool/download): add ShellSpec tests for build_url
+
+- `scripts/__tests__/download.unit.spec.sh` を作成
+- `build_url()` の正常系: `repo`・`tool-version` → GitHub API URL を stdout 出力
+  - 期待値: `https://api.github.com/repos/{repo}/releases/tags/v{version}`
+- `tool-version` の `v` プレフィックスは `normalize_version()` で除去済みを前提
+- テストが RED であることを確認
+
+#### Commit 6: feat(setup-tool/download): implement build_url in download.lib.sh
+
+- `scripts/_libs/download.lib.sh` を新規作成
+- `build_url()`: `repo`・`tool-version` を受け取り GitHub API URL を stdout 出力
+- double-source guard 付き
+- テストが GREEN であることを確認
+
+#### Commit 7: test(setup-tool/download): add ShellSpec tests for resolve_assets
+
+- `resolve_assets()` のユニットテスト（curl / jq モック使用）
+- シグネチャ: `resolve_assets <api_url> <tool_name> <arch_candidate>...`
+  （ARCH_CANDIDATES は配列展開 `"${ARCH_CANDIDATES[@]}"` で渡す）
+- GitHub API レスポンスからアセット一覧を取得する正常系
+- `ARCH_CANDIDATES` に一致する tar.gz の download URL 選択検証
+- checksums.txt 候補の選択検証:
+  - `checksums.txt` が存在する場合はそちらを採用
+  - `{tool-name}_{version}_checksums.txt` にフォールバック
+- 候補なし・API 失敗時の exit 2 を検証
+- テストが RED であることを確認
+
+#### Commit 8: feat(setup-tool/download): implement resolve_assets in download.lib.sh
+
+- `resolve_assets()`: シグネチャ `resolve_assets <api_url> <tool_name> <arch_candidate>...`
+  - 第3引数以降が arch 候補リスト（可変長引数 `"$@"` で受け取る）
+- `jq` で `assets[].name` と `assets[].browser_download_url` を抽出
+- arch 候補を順に確認し、一致する tar.gz の URL を選択（`ARCH_SUFFIX` も確定）
+- checksums.txt 候補を順に確認:
+  1. `checksums.txt`
+  2. `{tool-name}_{version}_checksums.txt`
+- `DOWNLOAD_URL`（1行目）・`CHECKSUM_URL`（2行目）・`ARCH_SUFFIX`（3行目）を1行1値で stdout に出力
+- 呼び出し元: `mapfile -t _assets < <(resolve_assets "${API_URL}" "${TOOL_NAME}" "${ARCH_CANDIDATES[@]}")`
+- 候補なし・API 失敗時は `::error::` を stderr に出力して exit 2
+- テストが GREEN であることを確認
+
+#### Commit 9: test(setup-tool/download): add ShellSpec tests for download_tool
+
+- `download_tool()` のユニットテスト（curl モック使用）
+- `DOWNLOAD_URL`・`CHECKSUM_URL`・`TEMP_DIR` を引数で受け取る
+- tar.gz 取得・`${TOOL_NAME}.tar.gz` へのリネーム検証
+- checksums.txt 取得検証
+- curl 失敗時の exit 2 を検証
+- テストが RED であることを確認
+
+#### Commit 10: feat(setup-tool/download): implement download_tool in download.lib.sh
+
+- `download_tool()`: `DOWNLOAD_URL`・`CHECKSUM_URL`・`TEMP_DIR` を引数で受け取る
+- tar.gz を curl で取得し `${TOOL_NAME}.tar.gz` にリネームして `TEMP_DIR` に保存
+- checksums.txt を curl で取得し `TEMP_DIR/checksums.txt` として保存
+- 失敗時は `::error::` を stderr に出力して exit 2
+- テストが GREEN であることを確認
+
+#### Commit 11: test(setup-tool/download): add ShellSpec tests for verify_checksum
+
+- `verify_checksum()` のユニットテスト
+- checksums.txt の検索キーは元ファイル名形式:
+  `{tool-name}_{version}_linux_{arch}.tar.gz`
+- sha256sum の対象は `${TOOL_NAME}.tar.gz`（リネーム後）
+- 正常系・エントリなし（exit 3）・ハッシュ不一致（exit 3）の各ケースを検証
+- テストが RED であることを確認
+
+#### Commit 12: feat(setup-tool/download): implement verify_checksum in download.lib.sh
+
+- `verify_checksum()`: `tool-name`・`tool-version`・`ARCH_SUFFIX`・`TEMP_DIR` を受け取る
+- 元ファイル名（`{tool-name}_{version}_linux_{arch}.tar.gz`）で `grep -w` 検索
+- sha256sum の対象は `TEMP_DIR/${TOOL_NAME}.tar.gz`（リネーム後）
+- エントリなし・ハッシュ不一致時は `::error::` を stderr に出力して exit 3
+- テストが GREEN であることを確認
+
+---
+
+### Phase 3: インストールライブラリ（install）
+
+#### Commit 13: test(setup-tool/install): add ShellSpec tests for extract_install
+
+- `scripts/__tests__/install.unit.spec.sh` を作成
+- `extract_install()` の正常系: tar.gz 展開・`tool-name` 一致バイナリを BIN_DIR に配置
+- パーミッション 755 の検証
+- `tool-name` 一致バイナリなし → exit 4 を検証
+- tar 失敗 → exit 4 を検証
+- テストが RED であることを確認
+
+#### Commit 14: feat(setup-tool/install): implement extract_install in install.lib.sh
+
+- `scripts/_libs/install.lib.sh` を新規作成
+- `extract_install()`: `tool-name`・`TEMP_DIR`・`BIN_DIR` を引数で受け取る
+- `tar -xzf "${TOOL_NAME}.tar.gz" -C "${TEMP_DIR}"` で展開
+- `tool-name` に一致するバイナリを `install -m 755` で `BIN_DIR` に配置
+- 一致なし・失敗時は `::error::` を stderr に出力して exit 4
+- double-source guard 付き
+- テストが GREEN であることを確認
+
+#### Commit 15: test(setup-tool/install): add ShellSpec tests for cleanup
+
+- `cleanup()` のユニットテスト
+- `TEMP_DIR` 存在時の削除検証
+- `TEMP_DIR` 削除済み時の冪等動作（exit 0）を検証
+- テストが RED であることを確認
+
+#### Commit 16: feat(setup-tool/install): implement cleanup in install.lib.sh
+
+- `cleanup()`: `TEMP_DIR` をパラメータで受け取り `rm -rf` で削除（冪等）
+- 成功時は `✓ Cleanup completed` を stdout に出力
+- テストが GREEN であることを確認
+
+---
+
+### Phase 4: オーケストレーションスクリプトと action.yml 統合
+
+#### Commit 17: test(setup-tool): add ShellSpec tests for setup-tool.sh
+
+- `scripts/__tests__/setup-tool.unit.spec.sh` を作成
+- 各ライブラリ関数をモック化して呼び出し順序を検証
+- 正常系: 全関数が順に呼び出されること
+- 異常系: 各フェーズ失敗時に適切な exit code で終了すること
+- `trap 'cleanup "${TEMP_DIR}"' EXIT` による cleanup の保証を検証
+  （TEMP_DIR を引数として渡すパターンであることを明示）
+- テストが RED であることを確認
+
+#### Commit 18: feat(setup-tool): implement setup-tool.sh
+
+- `scripts/setup-tool.sh` を新規作成
+- 各ライブラリを `.` で読み込み、処理の流れを制御:
+  1. `normalize_version()`: tool-version の v プレフィックスを除去（`version.lib.sh`）
+  2. `validate_inputs()`: `repo`・`tool-name`・正規化済み `tool-version` の入力検証
+     （`validation.lib.sh` の `validate_symbol()` を使用・`setup-tool.sh` 内にインライン定義）
+  3. `setup_dirs()`: BIN_DIR・TEMP_DIR 作成・GITHUB_ENV/PATH 書き込み（`dirs.lib.sh`）
+  4. `mapfile -t ARCH_CANDIDATES < <(detect_arch)`: runner.arch → 候補配列にキャプチャ（`arch.lib.sh`）
+  5. `mapfile -t _assets < <(resolve_assets "${API_URL}" "${TOOL_NAME}" "${ARCH_CANDIDATES[@]}")`: DOWNLOAD_URL（[0]）・CHECKSUM_URL（[1]）・ARCH_SUFFIX（[2]）を配列にキャプチャ（`download.lib.sh`）
+  6. `download_tool`: tar.gz + checksums.txt を TEMP_DIR に取得・リネーム（`download.lib.sh`）
+  7. `verify_checksum`: sha256sum 検証（`download.lib.sh`）
+  8. `extract_install`: tar.gz 展開・BIN_DIR にバイナリ配置（`install.lib.sh`）
+- `TEMP_DIR` はスクリプトスコープのグローバル変数として保持
+- `trap 'cleanup "${TEMP_DIR}"' EXIT` で TEMP_DIR を引数として渡し、成功・失敗問わず削除
+- テストが GREEN であることを確認
+
+#### Commit 19: chore(setup-tool): remove deprecated scripts
+
+- WHEN Commit 18（`setup-tool.sh`）のテストが GREEN になった後に実施する
+- 廃止予定スクリプトを削除:
+  - `scripts/setup-directories.sh`
+  - `scripts/download-tool.sh`
+  - `scripts/verify-checksum.sh`
+  - `scripts/extract-install.sh`
+  - `scripts/cleanup.sh`
+- 各機能は新規ライブラリ（`dirs.lib.sh`・`download.lib.sh`・`install.lib.sh`）に移行済み
+
+#### Commit 20: feat(setup-tool): implement action.yml
+
+- `.github/actions/setup-tool/action.yml` を新規作成（廃止スクリプト削除後）
+- `inputs` を定義:
+  - `repo`: `owner/repo` 形式（required: true）
+  - `tool-name`: ツール名（required: true）
+  - `tool-version`: `X.Y.Z` 形式（required: false・`default:` に固定バージョンを設定）
+- `runs.using: "composite"` で `setup-tool.sh` を1回呼び出すだけのシンプルな構成
+- `inputs` は `env:` 経由でスクリプトに渡す
+- `validate-environment`（`additional_apps: [jq]` 含む）が事前実行済みであることをコメントで明示
+- aglabo の `setup-actionlint/action.yml` 構造に準拠
+
+---
+
+## 3. Additional Tasks
+
+### 付加タスク A: 共通ライブラリへの移行と validate-environment 側修正
+
+調査の結果、`validate-environment` と `setup-tool` に重複する機能が存在する。
+共通ライブラリを `.github/actions/_libs/` に新設し、両 action から参照する構成に移行する。
+
+#### 共通化対象関数
+
+| 関数                              | 現在の所在                                            | 共通化後                                  |
+| --------------------------------- | ----------------------------------------------------- | ----------------------------------------- |
+| `normalize_version()`             | `setup-tool/scripts/_libs/common.lib.sh`              | `.github/actions/_libs/version.lib.sh`    |
+| `validate_symbol()`               | `setup-tool/scripts/_libs/validation.lib.sh`          | `.github/actions/_libs/validation.lib.sh` |
+| `out_status()` / `write_output()` | `validate-environment/scripts/` 各所                  | `.github/actions/_libs/output.lib.sh`     |
+| `check_env_var()`                 | `validate-environment/scripts/validate-git-runner.sh` | `.github/actions/_libs/env.lib.sh`        |
+
+#### 共通ライブラリ配置
+
+```bash
+.github/actions/_libs/
+├── version.lib.sh      # normalize_version()（setup-tool の common.lib.sh から移行）
+├── validation.lib.sh   # validate_symbol()（setup-tool の validation.lib.sh から移行）
+├── output.lib.sh       # out_status() / write_output()（validate-environment から抽出）
+└── env.lib.sh          # check_env_var()（validate-environment から抽出）
+```
+
+各 action からのパス解決: `. "${GITHUB_ACTION_PATH}/../_libs/<name>.lib.sh"`
+
+#### 実施順序
+
+付加タスク A（A-1〜A-3）は **Phase 1 の前に実施する**。
+Phase 1〜4 の新規ライブラリが最初から共通ライブラリを参照できるため、
+後からの切り替えリファクタリングが不要になる。
+
+実施順序: **A-1 → A-2 → A-3 → Phase 1 → Phase 2 → Phase 3 → Phase 4**
+
+#### 付加タスク A のコミット分解
+
+#### Commit A-1: feat(actions/libs): create shared library structure
+
+- `.github/actions/_libs/` ディレクトリを作成
+- `version.lib.sh`: `setup-tool/scripts/_libs/common.lib.sh` の `normalize_version()` を移行
+- `validation.lib.sh`: `setup-tool/scripts/_libs/validation.lib.sh` の `validate_symbol()` を移行
+- `output.lib.sh`: `validate-environment` 各スクリプトの `out_status()` / `write_output()` を抽出・統合
+- `env.lib.sh`: `validate-git-runner.sh` の `check_env_var()` を移行
+- 各ライブラリに double-source guard を付与
+
+#### Commit A-2: refactor(validate-environment): migrate to shared libs
+
+- `validate-apps.sh`・`validate-git-runner.sh`・`validate-permissions.sh` の重複関数を削除
+- `. "${GITHUB_ACTION_PATH}/../_libs/<name>.lib.sh"` で共通ライブラリを読み込む形に変更
+- 既存テストが引き続き GREEN であることを確認
+
+#### Commit A-3: refactor(setup-tool): migrate to shared libs
+
+- WHEN A-1・A-2 が完了し共通ライブラリの動作が確認された後に実施する
+- `setup-tool/scripts/_libs/common.lib.sh` を削除（`version.lib.sh` に移行済み）
+- `setup-tool/scripts/_libs/validation.lib.sh` を削除（共通 `validation.lib.sh` に移行済み）
+- `setup-tool` の各ライブラリで共通ライブラリを読み込む形に変更
+- 既存テストが引き続き GREEN であることを確認
+
+---
+
+## 4. Change History
+
+| Date       | Version | Description                                                                                                                   |
+| ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| 2026-06-07 | 1.0     | Initial implementation plan                                                                                                   |
+| 2026-06-07 | 1.1     | Phase 4 改訂: setup-tool.sh オーケストレーター追加・action.yml を1ステップに簡略化                                            |
+| 2026-06-07 | 1.2     | explore レビュー反映: 複数値返却規約（1行1値・mapfile キャプチャ）・normalize_version 呼び出し順序を明示                      |
+| 2026-06-07 | 1.3     | 付加タスク A 追加: 共通ライブラリ（.github/actions/_libs/）新設・validate-environment 側リファクタリング                      |
+| 2026-06-07 | 1.4     | explore レビュー残件反映: validate_inputs 帰属明示・cleanup の trap 引数渡し・廃止スクリプト削除コミット追加                  |
+| 2026-06-07 | 1.5     | explore レビュー2回目反映: 付加タスク A 実施順序確定（Phase 1 前）・Commit 17 trap 記述修正・ARCH_CANDIDATES 配列渡し方法明示 |
+| 2026-06-07 | 1.6     | harden レビュー反映: 実装品質基準（DR-08）追記・Commit 3 出力形式修正・A-3/Commit 19 に WHEN 条件追加                         |
+| 2026-06-07 | 1.7     | fix レビュー反映: Section 順序修正・用語統一（パラメータ→引数・正常系テスト→正常系）・見出し階層統一・クォート修正            |

--- a/docs/.deckrd/composite-action/setup-tool/requirements/requirements.md
+++ b/docs/.deckrd/composite-action/setup-tool/requirements/requirements.md
@@ -1,551 +1,322 @@
 ---
-title: "Requirements: setup-tool Composite Action"
+title: "Requirements: setup-tool composite action"
 module: "composite-action/setup-tool"
 status: Draft
-version: 1.0.4
-created: "2026-03-22"
+version: 1.0
+created: "2026-06-07"
 ---
 
-<!-- textlint-disable
-  ja-technical-writing/sentence-length,
-  ja-technical-writing/max-comma -->
+<!-- cspell:words rhysd -->
 <!-- markdownlint-disable line-length -->
-
-> **Normative Statement**
-> This document defines binding requirements.
-> Implementations MUST conform to this document.
-> RFC 2119 keywords apply to this document only.
 
 ## 1. Overview
 
 ### 1.1 Purpose
 
-GitHub Actions ワークフローから指定したツールの指定バージョンを GitHub Releases よりダウンロード・検証・インストールし、後続ステップから利用可能にする Composite Action を提供する。
+GitHub Actions の composite action として、指定された GitHub リポジトリのリリースから
+ツールをダウンロードし、チェックサム検証・アーカイブ展開を行い、
+ツールバイナリを実行可能な PATH に配置する。
 
 ### 1.2 Scope
 
-- GitHub Actions Composite Action (`action.yml`) の作成
-- `asset-template` による動的アセット URL 生成（URL 組み立てロジックは `url-builder` ライブラリに委譲）
-- `checksum-template` によるチェックサムファイル名の指定（デフォルト: `checksums.txt` + オーバーライド）
-- `runner.os` からの OS 自動解決（`Linux`→`linux` 固定、それ以外はエラー）
-- `runner.arch` からのアーキテクチャ自動解決（`X64`→`amd64`、`ARM64`→`arm64` の 2 系統のみ、それ以外はエラー）
-- SHA256 チェックサム検証 + 署名検証（Linux 限定、`checksum.lib.sh` にライブラリ化）
-- `${RUNNER_TEMP}/bin` へのバイナリインストールと PATH 追加
-- outputs: `install-path`, `tool-version`
+- 呼び出し元ワークフローから `repo`（`owner/repo` 形式）・`tool-name`・`tool-version` を受け取り、
+  GitHub Releases から tar.gz アーカイブをダウンロードする
+- `runner.arch` から CPU アーキテクチャを自動検出する
+- sha256 チェックサム検証を必須で実施する
+- tar.gz を展開し、バイナリを `RUNNER_TEMP/bin` に配置して `PATH` に追加する
+- Linux（ubuntu runner）のみを対象とする
 
 **Out of Scope**:
 
-- パッケージマネージャ経由のインストール (apt, brew 等)
-- tar.gz 以外のアーカイブ形式
-- macOS / Windows ランナーでの動作保証
-- インストール先ディレクトリのカスタマイズ
-- URL 組み立てロジックの直接実装（`url-builder` ライブラリに委譲）
+- `zip` など tar.gz 以外のアーカイブ形式への対応
+- macOS・Windows runner への対応
+- チェックサム検証のスキップオプション
+- GitHub Releases 以外のダウンロード元への対応
 
 ## 2. Context
 
-- Target Environment: GitHub Actions runner (Linux ubuntu-latest)
+- Target Environment: GitHub Actions ubuntu runner（Linux x86_64 / ARM64）
 - Related Components:
-  - `.github/actions/setup-tool/scripts/setup-directories.sh` (既存)
-  - `.github/actions/setup-tool/scripts/download-tool.sh` (既存、url-builder 利用に改修)
-  - `.github/actions/setup-tool/scripts/verify-checksum.sh` (既存、checksum ライブラリ利用に改修)
-  - `.github/actions/setup-tool/scripts/extract-install.sh` (既存)
-  - `.github/actions/setup-tool/scripts/cleanup.sh` (既存)
-  - `.github/actions/setup-tool/scripts/_libs/common.lib.sh` (既存、`resolve_os()`, `resolve_arch()` 追加)
-  - `.github/actions/setup-tool/scripts/_libs/url-builder.lib.sh` (新規)
-  - `.github/actions/setup-tool/scripts/_libs/checksum.lib.sh` (新規)
-  - `.github/actions/setup-tool/scripts/_libs/logging.lib.sh` (新規)
-  - `.github/actions/setup-tool/scripts/_libs/validation.lib.sh` (新規)
+  - `.github/actions/setup-tool/scripts/setup-directories.sh`
+  - `.github/actions/setup-tool/scripts/download-tool.sh`
+  - `.github/actions/setup-tool/scripts/verify-checksum.sh`
+  - `.github/actions/setup-tool/scripts/extract-install.sh`
+  - `.github/actions/setup-tool/scripts/cleanup.sh`
+  - `.github/actions/setup-tool/scripts/_libs/common.lib.sh`
+  - `.github/actions/setup-tool/scripts/_libs/validation.lib.sh`
 - Assumptions:
-  - GitHub Releases の tar.gz 形式アーカイブ（単一バイナリを含む）
-  - `sha256sum`、`curl`、`tar` コマンドが Linux ランナーで利用可能
-  - checksums ファイルのフォーマットは `<hash>  <filename>` 形式（sha256sum 標準形式）
-  - リリースタグは `v{x}.{y}.{z}` 形式（例: `v1.7.10`）
-  - `normalize_version()` は `{x}.{y}.{z}` 形式の数字のみを返す（v プレフィックスなし）
-
-### Library Architecture
-
-```text
-_libs/common.lib.sh        normalize_version(), resolve_os(), resolve_arch()
-_libs/url-builder.lib.sh   build_asset_filename(), build_checksum_filename(),
-                           build_download_url(), build_checksum_url()
-_libs/checksum.lib.sh      get_expected_checksum(), calc_actual_checksum(),
-                           verify_checksum()
-_libs/logging.lib.sh       log_info(), log_error(), log_success()
-_libs/validation.lib.sh    validate_required_var(), validate_version_format(),
-                           validate_template_nonempty(), validate_symbol(),
-                           validate_file_exists(), validate_dir_exists()
-```
+  - GitHub Releases の URL パターンは `{owner}/{repo}/releases/download/v{version}/{tool-name}_{version}_linux_{arch}.tar.gz`
+  - checksums.txt が同じリリースに存在する
+  - runner は curl および sha256sum を利用可能
 
 ### System Context Diagram
 
 ```text
-[CI Workflow Job ] --> +------------------------+ --> [GitHub Releases API  ]
-[action inputs   ] --> |   setup-tool action    | <-- [tool tar.gz + checksums]
-[runner.os (auto)] --> |  (Composite Action)    |
-[runner.arch(auto)] --> +------------------------+
-                                   |
-                                   v
-                        [${RUNNER_TEMP}/bin + PATH]
-                        (tool binary available to job)
+[Workflow Caller] --> +----------------------------+ --> [GitHub Releases API]
+  (repo,             |   setup-tool               |     (tar.gz + checksums.txt)
+   tool-name,        |   composite action         |
+   tool-version)     +----------------------------+ --> [Tool Binary]
+                             |                              (RUNNER_TEMP/bin,
+                      [runner.arch]                          added to PATH)
+                      (auto-detected)
 ```
 
 ## 3. Design Decisions (Summary)
 
-| ID    | Decision                                                     | Linked Record            |
-| ----- | ------------------------------------------------------------ | ------------------------ |
-| DR-01 | asset_template で動的 URL 生成（固定パターン廃止）           | decision-record.md#DR-01 |
-| DR-02 | checksum_template デフォルトは `checksums.txt`               | decision-record.md#DR-02 |
-| DR-03 | `{os}` は runner.os から自動解決（入力不要）                 | decision-record.md#DR-03 |
-| DR-04 | インストール先を `${RUNNER_TEMP}/bin` に固定（セキュリティ） | decision-record.md#DR-04 |
-| DR-05 | URL組み立てロジックを `url-builder` ライブラリとして分離     | decision-record.md#DR-05 |
-| DR-06 | `sha256sum` を Linux 限定とし、macOS フォールバックなし      | decision-record.md#DR-06 |
-| DR-07 | `{arch_suffix}` は runner.arch から自動解決（入力不要）      | decision-record.md#DR-07 |
-| DR-08 | スクリプト分離とコーディングスタイルの MUST 化               | decision-record.md#DR-08 |
-| DR-09 | 入力バリデーション要件の追加（tool-version, asset-template） | decision-record.md#DR-09 |
-| DR-10 | 5ライブラリ構成の確定と `resolve_os/arch` の common への配置 | decision-record.md#DR-10 |
+| ID    | Decision                                                 | Linked Record            |
+| ----- | -------------------------------------------------------- | ------------------------ |
+| DR-01 | アーキテクチャは runner.arch から自動検出                | decision-record.md#DR-01 |
+| DR-02 | チェックサム検証は必須（スキップ不可）                   | decision-record.md#DR-02 |
+| DR-03 | Linux (tar.gz) のみ対応                                  | decision-record.md#DR-03 |
+| DR-04 | repo は owner/repo 形式で呼び出し元が明示                | decision-record.md#DR-04 |
+| DR-05 | 既存スクリプト群を廃止し、関数ライブラリ式で新規実装する | decision-record.md#DR-05 |
 
 ## 4. Functional Requirements
 
-### REQ-F-001: ランナー環境からの OS・アーキテクチャ自動解決
+### REQ-F-001: 入力パラメータ検証
 
 - EARS Type: event-driven
 
 ```text
-GIVEN GitHub Actions Linux ランナーで action が実行されている状態で
-  WHEN action が起動される
-THEN the system SHALL runner.os を Linux→linux に変換して `{os}` を解決し、
-     runner.arch を X64→amd64、ARM64→arm64 に変換して `{arch_suffix}` を解決する。
-     runner.os が Linux 以外、または runner.arch が X64/ARM64 以外の場合は
-     エラーコード 1 で終了する。
+GIVEN composite action が呼び出された
+  WHEN repo・tool-name・tool-version が渡された
+THEN the system SHALL 各パラメータが非空かつ有効な形式であることを検証し、
+     不正な場合はエラーメッセージを出力してステップを失敗させる。
 ```
 
-**実装**: `common.lib.sh` の `resolve_os()`, `resolve_arch()` を使用する。
-
-**Rationale**: 対象環境は Linux 固定、アーキテクチャは X64/ARM64 の 2 系統のみ。未対応環境を明示的にエラーとすることで、サイレントな誤動作を防ぐ。`resolve_os/arch` は URL 組み立て以外でも汎用的に使用できるため `common.lib.sh` に配置する。
+**Rationale**: 不正な入力値による後続ステップの予期しない失敗を防ぐ。
 
 **Acceptance Criteria**:
 
-| AC ID  | Scenario                                                                          |
-| ------ | --------------------------------------------------------------------------------- |
-| AC-001 | Linux X64 ランナーで `{os}` が "linux"、`{arch_suffix}` が "amd64" に解決される   |
-| AC-002 | Linux ARM64 ランナーで `{os}` が "linux"、`{arch_suffix}` が "arm64" に解決される |
-| AC-025 | runner.arch が X64/ARM64 以外（例: X86）の場合にエラーコード 1 で終了する         |
+| AC ID  | Scenario                                        |
+| ------ | ----------------------------------------------- |
+| AC-001 | 有効なパラメータ → 検証通過                     |
+| AC-002 | tool-name が空文字 → エラー出力してステップ失敗 |
 
----
-
-### REQ-F-002: url-builder ライブラリによる URL 組み立て
+### REQ-F-002: アーキテクチャ自動検出
 
 - EARS Type: event-driven
 
 ```text
-GIVEN tool-name、tool-version、repo、asset-template、checksum-template が提供された状態で
-  WHEN url-builder ライブラリが呼び出される
-THEN the system SHALL 以下を生成する:
-     - asset ファイル名: asset-template 内の {tool_name}, {tool_version}, {os}, {arch_suffix} を解決した文字列
-     - checksum ファイル名: checksum-template 内の {tool_name}, {tool_version}, {arch_suffix} を解決した文字列
-     - ダウンロード URL: https://github.com/{repo}/releases/download/v{normalized_version}/{asset_filename}
-     - チェックサム URL: https://github.com/{repo}/releases/download/v{normalized_version}/{checksum_filename}
-     ここで {normalized_version} は normalize_version() による正規化後の値とする。
+GIVEN composite action が呼び出された
+  WHEN ステップが実行される
+THEN the system SHALL runner.arch の値から CPU アーキテクチャ文字列（x64→amd64, arm64→arm64）を
+     自動的にマッピングし、ダウンロード URL の構築に使用する。
 ```
 
-**実装**: `url-builder.lib.sh` の `build_asset_filename()`, `build_checksum_filename()`, `build_download_url()`, `build_checksum_url()` を使用する。`{repo}` は `org/repo` 形式（例: `rhysd/actionlint`）とする。
-
-**Rationale**: URL 組み立てロジックを分離することで単体テスト可能にし、download-tool.sh から再利用できる。`v` プレフィックスは `normalize_version()` で除去後に URL 構築時に付与する。
+**Rationale**: 呼び出し元がアーキテクチャを意識せずに利用できる。
 
 **Acceptance Criteria**:
 
-| AC ID  | Scenario                                                                                                         |
-| ------ | ---------------------------------------------------------------------------------------------------------------- |
-| AC-003 | `asset_template="{tool_name}_{tool_version}_linux_{arch_suffix}.tar.gz"` で actionlint の正しい URL が生成される |
-| AC-004 | `checksum_template="checksums.txt"` でチェックサム URL が正しく生成される                                        |
-| AC-005 | `tool-version=v1.7.10` 入力時、ダウンロード URL に `v1.7.10` が含まれる                                          |
+| AC ID  | Scenario                                     |
+| ------ | -------------------------------------------- |
+| AC-003 | runner.arch=X64 → amd64 にマッピングされる   |
+| AC-004 | runner.arch=ARM64 → arm64 にマッピングされる |
 
----
-
-### REQ-F-003: checksum-template のデフォルト動作
-
-- EARS Type: feature-based
-
-```text
-GIVEN action が起動された状態で
-  WHERE checksum-template input が省略されている
-THEN the system SHALL checksum-template として `checksums.txt` を使用する。
-```
-
-**Rationale**: `checksums.txt` は多くのツールで標準的なファイル名として使われており、省略時の有用なデフォルト。ghalint 形式（`{tool_name}_{tool_version}_checksums.txt`）等は明示指定でオーバーライドする。
-
-**Acceptance Criteria**:
-
-| AC ID  | Scenario                                                                                                                  |
-| ------ | ------------------------------------------------------------------------------------------------------------------------- |
-| AC-006 | checksum-template を省略した場合、チェックサムファイル名が `checksums.txt` になる                                         |
-| AC-007 | `checksum_template="{tool_name}_{tool_version}_checksums.txt"` 指定時、ghalint のチェックサムファイル名が正しく解決される |
-
----
-
-### REQ-F-004: checksums ファイルのパースと SHA256 照合
+### REQ-F-003: ツールダウンロード
 
 - EARS Type: event-driven
 
 ```text
-GIVEN Linux ランナーで sha256sum コマンドが実行可能な状態で
-  WHEN verify-checksum ステップが実行される
-THEN the system SHALL 以下を順に実行する:
-     1. checksums ファイルを `<hash>  <filename>` 形式（sha256sum 標準形式）としてパースする
-     2. 対象ファイル名に一致する行から期待ハッシュ値を取得する
-        エントリが存在しない場合はエラーコード 3 で終了する
-     3. sha256sum コマンドで実際の SHA256 を計算する
-     4. 期待値と照合し、不一致の場合はエラーコード 3 で終了する
+GIVEN 入力パラメータが検証済みでアーキテクチャが決定されている
+  WHEN ダウンロードステップが実行される
+THEN the system SHALL GitHub Releases から tar.gz アーカイブと checksums.txt を
+     一時ディレクトリにダウンロードする。
 ```
 
-**実装**: `checksum.lib.sh` の `get_expected_checksum()`, `calc_actual_checksum()`, `verify_checksum()` を使用する。checksums ファイルのフォーマットは `<hash>  <filename>` 形式（sha256sum 標準出力形式）に限定する。
-
-**Rationale**: checksums フォーマットを `sha256sum` 標準形式に固定することで、パース実装をシンプルかつ確実にする。フォーマットが異なるツールはスコープ外とし、将来の拡張は spec フェーズで別途設計する。
+**Rationale**: 安定した再現可能なツール取得を実現する。
 
 **Acceptance Criteria**:
 
-| AC ID  | Scenario                                                                              |
-| ------ | ------------------------------------------------------------------------------------- |
-| AC-008 | チェックサムが一致する場合にインストールが続行される                                  |
-| AC-009 | チェックサムが不一致の場合にエラーコード 3 で停止する                                 |
-| AC-010 | checksums ファイルに対象ファイルのエントリが存在しない場合にエラーコード 3 で停止する |
+| AC ID  | Scenario                                                            |
+| ------ | ------------------------------------------------------------------- |
+| AC-005 | 有効なリポジトリ・バージョン → ファイルが一時ディレクトリに存在する |
+| AC-006 | 存在しないバージョン → curl がエラーで失敗する                      |
 
----
-
-### REQ-F-012: バイナリ同一性検証（verify-identity）
+### REQ-F-004: チェックサム検証
 
 - EARS Type: event-driven
 
 ```text
-GIVEN ダウンロードが完了し、checksums ファイルと署名ファイルが取得された状態で
-  WHEN verify-identity ステップが実行される
-THEN the system SHALL 以下を順に実行する:
-     1. REQ-F-004 に従い SHA256 チェックサムを照合する
-     2. 署名検証を実行し、検証失敗の場合はエラーコード 3 で終了する
-     いずれかの検証に失敗した場合、後続のインストールステップは実行されない。
+GIVEN tar.gz と checksums.txt がダウンロード済みである
+  WHEN チェックサム検証ステップが実行される
+THEN the system SHALL sha256sum でダウンロードファイルのハッシュを検証し、
+     不一致の場合はエラーを出力してステップを失敗させる。
 ```
 
-**実装**: `checksum.lib.sh` を verify-identity の統合エントリポイントとして使用する。SHA256 照合と署名検証を独立した関数として実装し、それぞれ単体でテスト可能にする。
-
-**Rationale**: SHA256 だけでは「正規リリースからの配布」を保証できない（リポジトリ侵害時に checksums.txt も同時改ざん可能）。署名検証を加えることで supply chain attack に対する防御層を増やす。2 つの検証を `verify-identity` として 1 ステップに統合することで、action.yml のフロー管理をシンプルに保つ。
-
-**Note**: 署名検証の信頼アンカー設計（公開鍵配布元・署名対象・鍵ローテーション）は Open Question (Section 10) として spec フェーズで決定する。
+**Rationale**: ダウンロードファイルの完全性と真正性を保証する。
 
 **Acceptance Criteria**:
 
-| AC ID  | Scenario                                                                    |
-| ------ | --------------------------------------------------------------------------- |
-| AC-028 | SHA256 照合・署名検証の両方が成功した場合にインストールが続行される         |
-| AC-029 | 署名検証が失敗した場合にエラーコード 3 で停止し、インストールが実行されない |
+| AC ID  | Scenario                                              |
+| ------ | ----------------------------------------------------- |
+| AC-007 | ハッシュ一致 → 検証通過                               |
+| AC-008 | ファイルが破損（ハッシュ不一致） → エラー出力して失敗 |
 
----
-
-### REQ-F-005: ダウンロード失敗時のエラーハンドリング
+### REQ-F-005: アーカイブ展開とバイナリ配置
 
 - EARS Type: event-driven
 
 ```text
-GIVEN download-tool ステップが実行されている状態で
-  WHEN curl によるダウンロードが失敗する（404、ネットワークエラー等）
-THEN the system SHALL エラーコード 2 で終了し、失敗した URL を含むエラーメッセージを出力する。
+GIVEN チェックサム検証が成功している
+  WHEN 展開・配置ステップが実行される
+THEN the system SHALL tar.gz を展開し、ツールバイナリを RUNNER_TEMP/bin に配置して
+     実行権限（755）を付与し、PATH に追加する。
 ```
 
-**実装**: エラーメッセージは `logging.lib.sh` の `log_error()` を使用する。
+**Rationale**: 後続ステップからツールを直接呼び出せるようにする。
 
 **Acceptance Criteria**:
 
-| AC ID  | Scenario                                                      |
-| ------ | ------------------------------------------------------------- |
-| AC-011 | 存在しないバージョンを指定した場合にエラーコード 2 で停止する |
+| AC ID  | Scenario                                              |
+| ------ | ----------------------------------------------------- |
+| AC-009 | 展開・配置後 → tool-name コマンドが PATH から実行可能 |
+| AC-010 | バイナリに実行権限 755 が付与されている               |
 
----
-
-### REQ-F-006: バイナリのインストールと PATH 追加
-
-- EARS Type: event-driven
-
-```text
-GIVEN チェックサム検証が成功した状態で
-  WHEN extract-install ステップが実行される
-THEN the system SHALL 以下を順に実行する:
-     1. tar.gz を TEMP_DIR に展開する
-     2. 展開物から tool-name と一致するファイルを特定する
-     3. そのファイルを `${RUNNER_TEMP}/bin/<tool-name>` として 755 権限でインストールする
-     4. `${RUNNER_TEMP}/bin` を GITHUB_PATH に追加する
-     tool-name と一致するファイルが存在しない場合はエラーコード 4 で終了する。
-```
-
-**実装**: `extract-install.sh` を関数化し、各ステップを独立してテスト可能にする。
-
-**Rationale**: インストール先バイナリ名を `tool-name` に正規化することで、tar.gz 内のディレクトリ構造（例: `actionlint_1.7.10_linux_amd64/actionlint`）に依存せず確実にインストールできる。インストール先を `${RUNNER_TEMP}/bin` に固定することで、システムディレクトリへの書き込みリスクを排除する。
-
-**Acceptance Criteria**:
-
-| AC ID  | Scenario                                                                                                      |
-| ------ | ------------------------------------------------------------------------------------------------------------- |
-| AC-012 | インストール後に `${RUNNER_TEMP}/bin/<tool-name>` として後続ステップからツールが実行可能である                |
-| AC-013 | 同一ジョブで本 action を複数回呼び出した場合、2回目以降も正常にインストールされる（冪等性）                   |
-| AC-026 | tar.gz 内のディレクトリ構造に関わらず、`tool-name` のバイナリが `${RUNNER_TEMP}/bin/<tool-name>` に配置される |
-| AC-027 | tar.gz 内に tool-name と一致するファイルが存在しない場合にエラーコード 4 で終了する                           |
-
----
-
-### REQ-F-007: outputs の提供
-
-- EARS Type: event-driven
-
-```text
-GIVEN インストールが正常完了した状態で
-  WHEN action が終了する
-THEN the system SHALL install-path（`${RUNNER_TEMP}/bin`）と
-     tool-version（normalize_version() による正規化後の X.Y.Z 形式、v プレフィックスなし）を
-     outputs として提供する。
-```
-
-**実装**: tool-version の正規化は `common.lib.sh` の `normalize_version()` を使用する。
-
-```text
-```
-
-**Acceptance Criteria**:
-
-| AC ID  | Scenario                                                              |
-| ------ | --------------------------------------------------------------------- |
-| AC-014 | install-path が `${RUNNER_TEMP}/bin` を返す                           |
-| AC-015 | `tool-version=v1.7.10` 入力時、tool-version output が `1.7.10` を返す |
-| AC-016 | `tool-version=1.7` 入力時、tool-version output が `1.7.0` を返す      |
-
----
-
-### REQ-F-008: 一時ファイルのクリーンアップ
+### REQ-F-006: 一時ファイルのクリーンアップ
 
 - EARS Type: state-driven
 
 ```text
-GIVEN action のすべてのステップが完了または失敗した状態で
-  WHILE cleanup ステップが `if: always()` 条件で実行される
-THEN the system SHALL TEMP_DIR を削除し、ランナーの一時領域を解放する。
+GIVEN composite action のすべてのステップが完了した（成功・失敗問わず）
+  WHILE if: always() 条件が成立している
+THEN the system SHALL 一時ディレクトリ（TEMP_DIR）を削除する。
 ```
+
+**Rationale**: ランナーのディスク容量を消費しないようにする。
 
 **Acceptance Criteria**:
 
-| AC ID  | Scenario                                         |
-| ------ | ------------------------------------------------ |
-| AC-017 | 成功時に TEMP_DIR が削除される                   |
-| AC-018 | ダウンロード失敗時でもクリーンアップが実行される |
-
----
-
-### REQ-F-009: セキュリティ制約（インストール先固定）
-
-- EARS Type: unwanted behavior
-
-```text
-GIVEN action が実行されている状態で
-  NOT DO インストール先ディレクトリをユーザー入力で変更する
-THEN the system SHALL インストール先を常に `${RUNNER_TEMP}/bin` に固定する。
-```
-
-**Rationale**: ユーザーが任意パスを指定できると `/usr/local/bin` 等のシステムディレクトリへの書き込みリスクが生じる。
-
----
-
-### REQ-F-010: 入力値バリデーション
-
-- EARS Type: event-driven
-
-```text
-GIVEN action が起動された状態で
-  WHEN 以下のいずれかの条件に該当する場合:
-     (a) tool-version が X、X.Y、X.Y.Z 形式（v プレフィックス任意）以外
-     (b) asset-template が空文字または未指定
-     (c) tool-name が ^[a-z][a-z0-9_-]*$ パターン以外の文字を含む
-THEN the system SHALL エラーメッセージを出力してエラーコード 1 で終了する。
-```
-
-**実装**: `validation.lib.sh` の各関数を使用:
-
-- `validate_version_format()`: (a) の検証、`normalize_version()` と連携
-- `validate_template_nonempty()`: (b) の検証
-- `validate_symbol()`: (c) の検証、パターン `^[a-z][a-z0-9_-]*$`（先頭英小文字必須、以降は英小文字・数字・ハイフン・アンダースコア）
-
-**Rationale**: GitHub のバイナリ命名規則では数字始まり・記号始まりは存在しないため、`^[a-z][a-z0-9_-]*$` で十分かつ安全。repo バリデーション（org/repo 形式）は REQ-F-011 に一本化。早期バリデーションにより curl 失敗より前に設定ミスを検出できる。
-
-**Acceptance Criteria**:
-
-| AC ID  | Scenario                                                          |
-| ------ | ----------------------------------------------------------------- |
-| AC-019 | `tool-version=latest` 指定時にエラーコード 1 で停止する           |
-| AC-020 | `asset-template` 未指定時にエラーコード 1 で停止する              |
-| AC-021 | `tool-name=MyTool`（大文字含む）指定時にエラーコード 1 で停止する |
-| AC-022 | `repo=rhysd/actionlint` 指定時にバリデーションを通過する          |
-
----
-
-### REQ-F-011: `repo` 形式バリデーション
-
-- EARS Type: event-driven
-
-```text
-GIVEN action が起動された状態で
-  WHEN repo input が `org/repo` 形式（スラッシュ区切り、各部分が ^[a-z][a-z0-9_-]*$ に適合）以外の場合
-THEN the system SHALL エラーメッセージを出力してエラーコード 1 で終了する。
-```
-
-**実装**: `validation.lib.sh` の `validate_symbol()` を `/` で分割した org 部・repo 部それぞれに適用する。
-
-**Acceptance Criteria**:
-
-| AC ID  | Scenario                                                                     |
-| ------ | ---------------------------------------------------------------------------- |
-| AC-023 | `repo=rhysd/actionlint` が正常に通過する                                     |
-| AC-024 | `repo=ActionLint`（スラッシュなし・大文字）指定時にエラーコード 1 で停止する |
-
----
+| AC ID  | Scenario                                          |
+| ------ | ------------------------------------------------- |
+| AC-011 | 正常完了後 → 一時ディレクトリが存在しない         |
+| AC-012 | 中間ステップ失敗後 → 一時ディレクトリが存在しない |
 
 ## 5. Non-Functional Requirements
 
 ### REQ-NF-001: セキュリティ
 
-インストール先は `${RUNNER_TEMP}/bin` に固定し、外部から変更不可能とする。ダウンロードしたすべてのバイナリは SHA256 検証を必須とする。
+チェックサム検証は SHA256 を使用し、検証失敗時は必ずステップを失敗させる。
+バイナリのパーミッションは 755 とし、不要な書き込み権限を付与しない。
 
-### REQ-NF-002: 信頼性
+### REQ-NF-002: 冪等性
 
-ダウンロード失敗（ネットワークエラー、リリース不存在）およびチェックサム不一致の場合、失敗の理由に応じたエラーコードと `::error::` プレフィックスのエラーメッセージで失敗する。
+同じパラメータで複数回実行した場合、同じ結果を得られる。
 
-### REQ-NF-003: 保守性（MUST）
+### REQ-NF-003: Maintainability
 
-各処理フェーズはスクリプト単位で 1 責任となるよう分離し、ライブラリ関数は単体でテスト可能にする。ライブラリは以下の 5 構成:
+各処理（ディレクトリ準備・ダウンロード・検証・展開・クリーンアップ）は
+独立したスクリプトに分離する。
 
-- `common.lib.sh`: `normalize_version()`, `resolve_os()`, `resolve_arch()`
-- `url-builder.lib.sh`: URL・ファイル名組み立て関数群
-- `checksum.lib.sh`: チェックサム取得・計算・検証関数群
-- `logging.lib.sh`: `log_info()`, `log_error()`, `log_success()`
-- `validation.lib.sh`: 入力バリデーション関数群（`validate_symbol()` 含む）
+### REQ-NF-004: Testability
 
-### REQ-NF-004: 互換性（MUST）
-
-`validate-environment` action の実装パターンに必ず準拠すること:
-
-- ステップ内のスクリプト呼び出し: `bash "${GITHUB_ACTION_PATH}/scripts/<name>.sh"`
-- パラメータ渡し: `env:` ブロック使用
-- シェル指定: `shell: bash` の明示
+各スクリプトは ShellSpec によるユニットテストが可能な構造とする。
 
 ## 6. Constraints
 
-### REQ-C-001: Linux 限定
+### REQ-C-001: 実行環境
 
-GitHub Actions の Ubuntu ランナー（ubuntu-latest、ubuntu-22.04 等）を対象とする。macOS・Windows ランナーはスコープ外とする。`sha256sum` コマンドに依存するため macOS フォールバックは提供しない。
+GitHub Actions ubuntu runner（Linux）上でのみ動作を保証する。
+macOS・Windows runner は対象外。
 
-### REQ-C-002: tar.gz 形式限定
+### REQ-C-002: アーカイブ形式
 
-ダウンロード対象は tar.gz 形式のアーカイブのみとする。zip 等の他形式はスコープ外とする。
+tar.gz 形式のみ対応する。zip など他の形式は対象外。
 
-### REQ-C-003: GitHub Releases 限定
+### REQ-C-003: チェックサム検証必須
 
-ダウンロード元は GitHub Releases（`https://github.com/{repo}/releases/download/v{tool_version}/`）に限定する。`{repo}` は `org/repo` 形式（例: `rhysd/actionlint`）とする。GitHub Releases の tag は `v{x}.{y}.{z}` 形式（例: `v1.7.10`）を前提とする。`v` プレフィックスなしのタグを使用するツールは本 action のスコープ外とする。
+チェックサム検証をスキップするオプションは提供しない。
 
-### REQ-C-004: 最小権限
+### REQ-C-004: GitHub Releases URL パターン
 
-action に必要な GitHub permissions は `contents: read` のみとする。
+ダウンロード URL は以下のパターンに従う:
+`https://github.com/{owner}/{repo}/releases/download/v{version}/{tool-name}_{version}_linux_{arch}.tar.gz`
+
+### REQ-C-005: 関数ライブラリ式の新規実装
+
+既存の個別スクリプト（`setup-directories.sh`, `download-tool.sh`, `verify-checksum.sh`,
+`extract-install.sh`, `cleanup.sh`）を参考実装として扱い、新規実装を作成する。
+各処理（ディレクトリ準備・URL構築・ダウンロード・検証・展開・配置・クリーンアップ）は
+ファイル分割の有無に関わらず、関数として定義し関数呼び出しで構造化する。
+コードは読みやすさを優先し、処理の意図が関数名と呼び出し順から明確に読み取れる構成とする。
 
 ## 7. User Stories
 
-- US-01: CI ワークフロー作者として、actionlint のバージョンを指定してインストールしたい。なぜなら、ワークフロー品質チェックを再現可能な環境で実行したいから。（→ REQ-F-002, REQ-F-006）
-- US-02: CI ワークフロー作者として、betterleaks のような非標準命名のチェックサムにも対応したい。なぜなら、ツールごとに異なるチェックサムファイル名に個別対応したくないから。（→ REQ-F-003）
-- US-03: セキュリティ担当者として、ダウンロードしたバイナリが改ざんされていないことを確認したい。なぜなら、supply chain attack を防ぎたいから。（→ REQ-F-004）
-- US-04: CI ワークフロー作者として、OS・アーキテクチャを指定せずに action を使いたい。なぜなら、runner 環境に応じた設定ミスを防ぎたいから。（→ REQ-F-001）
-- US-05: CI ワークフロー作者として、インストール後のバージョンを後続ステップで参照したい。なぜなら、インストールされたバージョンをログやアーティファクトに記録したいから。（→ REQ-F-007）
+- As a CI engineer, I want to install a specific version of a tool in a GitHub Actions workflow. Because I want reproducible builds.
+- As a CI engineer, I want the architecture to be auto-detected. Because I don't want to hardcode platform-specific values in each workflow.
+- As a security engineer, I want checksum verification to be mandatory. Because I want to ensure the integrity of downloaded binaries.
+- As a workflow author, I want cleanup to run even on failure. Because I want to avoid leaving temporary files on the runner.
+- As a workflow author, I want to specify the tool repository as owner/repo. Because it uniquely identifies the source of the binary.
 
 ## 8. Acceptance Criteria
 
-> 代表的なシナリオを記載する。全 AC の定義は Section 9 Traceability を参照。
-
 ```gherkin
-# AC-003: asset_template で actionlint の URL が正しく生成される
-# Requirement: REQ-F-002
-Scenario: 標準テンプレートで actionlint の URL が正しく生成される
-  Given tool-name=actionlint, tool-version=1.7.10, repo=rhysd/actionlint
-  And   asset-template="{tool_name}_{tool_version}_linux_{arch_suffix}.tar.gz"
-  And   runner.os=Linux, runner.arch=X64
-  When  url-builder ライブラリが呼び出される
-  Then  ダウンロード URL が "https://github.com/rhysd/actionlint/releases/download/v1.7.10/actionlint_1.7.10_linux_amd64.tar.gz" になる
-
-# AC-001: Linux X64 ランナーでの環境変数自動解決
+# AC-001: 有効なパラメータで検証が通過する
 # Requirement: REQ-F-001
-Scenario: Linux X64 ランナーで OS・アーキテクチャが自動解決される
-  Given runner.os が "Linux" で runner.arch が "X64" である
-  When  action が起動される
-  Then  {os} が "linux" に、{arch_suffix} が "amd64" に解決される
+Scenario: 有効なパラメータで検証が通過する
+  Given composite action が repo="rhysd/actionlint" tool-name="actionlint" tool-version="1.7.7" で呼び出された
+  When 入力検証ステップが実行される
+  Then ステップが成功する
 
-# AC-008: チェックサムが一致する場合にインストールが続行される
+# AC-007: チェックサムが一致する場合に検証が通過する
 # Requirement: REQ-F-004
-Scenario: チェックサムが一致する場合にインストールが続行される
-  Given ダウンロード済み tar.gz と checksums.txt が TEMP_DIR に存在する
-  When  verify-checksum ステップが実行される
-  Then  SHA256 が一致し、後続の extract-install ステップが実行される
+Scenario: チェックサムが一致する場合に検証が通過する
+  Given checksums.txt とアーカイブが一時ディレクトリにダウンロードされている
+  When チェックサム検証ステップが実行される
+  Then ステップが成功する
 
-# AC-009: チェックサムが不一致の場合にエラーで停止する
+# AC-009: ツールバイナリが PATH から実行可能になる
+# Requirement: REQ-F-005
+Scenario: ツールバイナリが PATH から実行可能になる
+  Given アーカイブが展開・配置済みである
+  When 後続ステップで tool-name コマンドを実行する
+  Then コマンドが正常に起動する
+
+# AC-008: ハッシュ不一致でステップが失敗する
 # Requirement: REQ-F-004
-Scenario: チェックサムが不一致の場合にエラーで停止する
-  Given 改ざんされた tar.gz が TEMP_DIR に存在する
-  When  verify-checksum ステップが実行される
-  Then  エラーコード 3 で action が失敗し、後続ステップは実行されない
+Scenario: ハッシュ不一致でステップが失敗する
+  Given 破損したアーカイブが一時ディレクトリにある
+  When チェックサム検証ステップが実行される
+  Then ステップがエラーメッセージを出力して失敗する
 
-# AC-019: tool-version に無効な値を指定した場合
-# Requirement: REQ-F-010
-Scenario: tool-version に "latest" を指定した場合にエラーで停止する
-  Given tool-version="latest" が指定されている
-  When  action が起動される
-  Then  エラーコード 1 で action が失敗する
-
-# AC-018: ダウンロード失敗時でもクリーンアップが実行される
-# Requirement: REQ-F-008
-Scenario: ダウンロード失敗時でもクリーンアップが実行される
-  Given ネットワークエラーでダウンロードが失敗した
-  When  cleanup ステップが if: always() で実行される
-  Then  TEMP_DIR が削除される
+# AC-012: 中間ステップ失敗後でもクリーンアップが実行される
+# Requirement: REQ-F-006
+Scenario: 中間ステップ失敗後でもクリーンアップが実行される
+  Given ダウンロードステップが失敗した
+  When クリーンアップステップが if: always() で実行される
+  Then 一時ディレクトリが削除されている
 ```
 
-## 9. Traceability
+## 9. Open Questions
 
-| REQ ID     | AC IDs                         | Type           |
-| ---------- | ------------------------------ | -------------- |
-| REQ-F-001  | AC-001, AC-002, AC-025         | Functional     |
-| REQ-F-002  | AC-003, AC-004, AC-005         | Functional     |
-| REQ-F-003  | AC-006, AC-007                 | Functional     |
-| REQ-F-004  | AC-008, AC-009, AC-010         | Functional     |
-| REQ-F-005  | AC-011                         | Functional     |
-| REQ-F-006  | AC-012, AC-013, AC-026, AC-027 | Functional     |
-| REQ-F-007  | AC-014, AC-015, AC-016         | Functional     |
-| REQ-F-008  | AC-017, AC-018                 | Functional     |
-| REQ-F-009  | —                              | Functional     |
-| REQ-F-010  | AC-019, AC-020, AC-021, AC-022 | Functional     |
-| REQ-F-011  | AC-023, AC-024                 | Functional     |
-| REQ-NF-001 | —                              | Non-Functional |
-| REQ-NF-002 | —                              | Non-Functional |
-| REQ-NF-003 | —                              | Non-Functional |
-| REQ-NF-004 | —                              | Non-Functional |
-| REQ-C-001  | —                              | Constraint     |
-| REQ-C-002  | —                              | Constraint     |
-| REQ-C-003  | —                              | Constraint     |
-| REQ-C-004  | —                              | Constraint     |
-| REQ-F-012  | AC-028, AC-029                 | Functional     |
+| Question                                                                | Type       | Impact Area     | Owner |
+| ----------------------------------------------------------------------- | ---------- | --------------- | ----- |
+| runner.arch に X64/ARM64 以外の値が来た場合の動作を定義する必要があるか | EARS/GIVEN | REQ-F-002 scope | TBD   |
+| tool-version に "latest" などの動的な値を許容するか                     | scope      | REQ-F-001       | TBD   |
+| checksums.txt が存在しないリリースへの対処は必要か                      | scope      | REQ-F-004       | TBD   |
 
-## 10. Open Questions
+## 10. Traceability
 
-| Question                                                                                                                  | Type     | Impact Area | Owner | Status                                                   |
-| ------------------------------------------------------------------------------------------------------------------------- | -------- | ----------- | ----- | -------------------------------------------------------- |
-| ~~GitHub Releases の tag が `v` プレフィックスなし形式のツールへの対応方針（現在は `v{tool_version}` 固定）~~             | スコープ | REQ-C-003   | —     | クローズ: `v{x}.{y}.{z}` 固定とし、非対応は Out of Scope |
-| 署名検証の信頼アンカー設計: 公開鍵の配布元・固定方法、署名対象（asset 本体か checksums.txt か）、鍵ローテーション時の扱い | 設計     | REQ-F-004   | TBD   | Open                                                     |
+| REQ ID     | AC IDs         | Type           |
+| ---------- | -------------- | -------------- |
+| REQ-F-001  | AC-001, AC-002 | Functional     |
+| REQ-F-002  | AC-003, AC-004 | Functional     |
+| REQ-F-003  | AC-005, AC-006 | Functional     |
+| REQ-F-004  | AC-007, AC-008 | Functional     |
+| REQ-F-005  | AC-009, AC-010 | Functional     |
+| REQ-F-006  | AC-011, AC-012 | Functional     |
+| REQ-NF-001 | —              | Non-Functional |
+| REQ-NF-002 | —              | Non-Functional |
+| REQ-NF-003 | —              | Non-Functional |
+| REQ-NF-004 | —              | Non-Functional |
+| REQ-C-001  | —              | Constraint     |
+| REQ-C-002  | —              | Constraint     |
+| REQ-C-003  | —              | Constraint     |
+| REQ-C-004  | —              | Constraint     |
+| REQ-C-005  | —              | Constraint     |
 
 ## 11. Change History
 
-| Date       | Version | Description                                                                                                                                                                                                                                                                         |
-| ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 2026-03-22 | 1.0.0   | Initial release                                                                                                                                                                                                                                                                     |
-| 2026-03-22 | 1.1.0   | review(explore)反映: url-builder ライブラリ分離、Linux 限定明記、checksum デフォルト `checksums.txt`、arch_suffix 自動解決追加、ダウンロードエラー要件追加                                                                                                                          |
-| 2026-03-22 | 1.2.0   | review(harden)反映: REQ-NF-003/004 MUST昇格、REQ-F-010/011 新規追加、5ライブラリ構成確定（checksum.lib.sh追加、resolve_os/arch をcommonへ）、validate_symbol() パターン確定                                                                                                         |
-| 2026-03-22 | 1.3.0   | review(fix)反映: input 参照をケバブケースに統一（asset-template/checksum-template）、REQ-F-010(c) から repo 除外し REQ-F-011 に一本化、REQ-F-007 に normalize_version() 参照追加、AC-005 説明明確化、Section 8 注記追加、Typo 修正                                                  |
-| 2026-03-22 | 1.4.0   | codex-review 反映: OS=Linux 固定・arch=X64/ARM64 限定の明示エラー化（AC-025 追加）、checksums フォーマットを `<hash>  <filename>` 形式に固定、単一バイナリ前提をREQ-F-006に追加、`v{x}.{y}.{z}` タグ固定・非対応を Out of Scope 明記、署名検証 Open Question 追加、Assumptions 強化 |
-| 2026-03-22 | 1.5.0   | spec 構造設計に向けた要件精緻化: REQ-F-006 にインストール先バイナリ名 `<tool-name>` 正規化・エラーコード 4・AC-026/027 追加、REQ-F-004 を checksum parsing 専用に整理、REQ-F-012（verify-identity）新規追加（SHA256 + 署名検証の統合ステップ・AC-028/029）                          |
+| Date       | Version | Description     |
+| ---------- | ------- | --------------- |
+| 2026-06-07 | 1.0.0   | Initial release |

--- a/docs/.deckrd/composite-action/setup-tool/specifications/specifications.md
+++ b/docs/.deckrd/composite-action/setup-tool/specifications/specifications.md
@@ -1,0 +1,354 @@
+---
+title: "Design Specification: setup-tool composite action"
+based-on: requirements.md v1.0
+status: Draft
+---
+
+<!-- markdownlint-disable line-length -->
+
+## 1. Overview
+
+### 1.1 Purpose
+
+本仕様は `setup-tool` composite action の振る舞いを定義する。
+指定された GitHub リポジトリのリリースからツールをダウンロードし、
+チェックサム検証・アーカイブ展開を行い、バイナリを実行可能な PATH に配置するまでの
+各ユニットの責務・前後条件・エラー処理・ユニット間のインタラクションを規定する。
+
+### 1.2 Scope
+
+本仕様は `setup-tool` composite action の**外部から観測可能な振る舞い**を定義する。
+実装詳細（スクリプト内部ロジック・変数名・ファイル構造）は明示的にスコープ外とする。
+
+---
+
+## 2. Design Principles
+
+### 2.1 Classification Philosophy
+
+各処理ユニットは単一責務を持ち、関数として定義する。
+ユニット間のインターフェースは関数呼び出しと同じ規則に従う:
+入力はパラメータ（位置引数または環境変数）で渡し、結果は stdout で返す。
+ファイル分割の有無に関わらず、この呼び出し規則を統一する。
+
+**複数値返却規約**: 複数の値を返す場合は 1行 = 1値 の形式で空行を挟まずに出力する。
+呼び出し元は `mapfile` または `read` で行単位にキャプチャする。
+
+```bash
+# 出力側（例: resolve_assets の3値出力）
+echo "${DOWNLOAD_URL}"
+echo "${CHECKSUM_URL}"
+echo "${ARCH_SUFFIX}"
+
+# 受け取り側
+mapfile -t _results < <(resolve_assets "${API_URL}" "${TOOL_NAME}" "${ARCH_CANDIDATES[@]}")
+DOWNLOAD_URL="${_results[0]}"
+CHECKSUM_URL="${_results[1]}"
+ARCH_SUFFIX="${_results[2]}"
+```
+
+<!-- impl-note: 各ユニットは bash 関数として実装し、action.yml の steps から . (ドット演算子) + 関数呼び出しで起動する。
+  source は使用しない（POSIX 準拠・プロジェクト規約）。
+  例: . "${GITHUB_ACTION_PATH}/scripts/arch.lib.sh" && detect_arch
+  分割スクリプトの場合も: bash script.sh <args> の stdout を $() でキャプチャして次ユニットへ渡す。
+  GITHUB_ENV への書き込みは「外部への副作用」として明示的に限定する（ユニット間の結果受け渡しには使わない）。-->
+
+### 2.2 Design Assumptions
+
+- `validate-environment` composite action が呼び出し元ワークフローで事前実行済みであること
+  （アーキテクチャ・必要ツールの検証は完了済みとみなす）
+- GitHub Releases は public リポジトリであり、認証トークンは不要
+- ランナーは `curl` および `sha256sum` を利用可能（validate-environment で保証済み）
+- URL パターン: `https://github.com/{owner}/{repo}/releases/download/v{version}/{tool-name}_{version}_linux_{arch}.tar.gz`
+- スクリプトへのパス解決は `GITHUB_ACTION_PATH` を起点とした相対パスで行う（`dirname`・`realpath` は使用しない）
+- `BIN_DIR` は `${RUNNER_TEMP}/bin` 固定、`TEMP_DIR` は `mktemp -d` で動的生成する
+
+<!-- impl-note: 参考実装 C:\Users\atsushifx\workspaces\develop\.github-aglabo\.github\actions\scripts
+  - スクリプト呼び出し: "${GITHUB_ACTION_PATH}/../scripts/<name>.sh"
+  - 引数パターン: readonly VAR="${1:-${VAR:?Error: VAR required}}"
+  - GITHUB_ENV への書き込みで後続ステップに BIN_DIR / TEMP_DIR を引き渡す -->
+
+### 2.3 External Design Summary
+
+> **Source**: Phase D（ユーザー確認済みデザイン）および Phase E（外部設計ダイアローグ）から導出。
+
+#### Feature Decomposition
+
+| Unit            | Responsibility                                                      | REQ Coverage         |
+| --------------- | ------------------------------------------------------------------- | -------------------- |
+| validate-inputs | repo/tool-name/tool-version の入力値検証                            | REQ-F-001            |
+| detect-arch     | runner.arch から arch 候補リスト生成                                | REQ-F-002            |
+| setup-dirs      | BIN_DIR/TEMP_DIR 作成・環境変数書き込み                             | REQ-F-005            |
+| build-url       | GitHub Releases の tar.gz URL / checksums.txt URL を構築する        | REQ-F-003            |
+| resolve-arch    | curl --head -L で候補を順に確認し使用する arch suffix を決定する    | REQ-F-002, REQ-F-003 |
+| download        | tar.gz + checksums.txt のダウンロード                               | REQ-F-003            |
+| verify-checksum | SHA256 ハッシュ検証                                                 | REQ-F-004            |
+| extract-install | tar.gz 展開・tool-name に一致するバイナリを配置・パーミッション付与 | REQ-F-005            |
+| cleanup         | 一時ディレクトリ削除（常に実行）                                    | REQ-F-006            |
+
+<!-- impl-note:
+  ライブラリ構成（B案）:
+  - dirs.lib.sh    → setup-dirs ユニット（BIN_DIR=${RUNNER_TEMP}/bin, TEMP_DIR=$(mktemp -d)）
+  - arch.lib.sh    → detect-arch / resolve-arch ユニット
+  - download.lib.sh → build-url / download ユニット
+  - install.lib.sh  → extract-install / cleanup ユニット
+
+  スクリプト呼び出しパターン（aglabo 参考実装に準拠）:
+  - ライブラリ読み込み: . "${GITHUB_ACTION_PATH}/scripts/<name>.lib.sh"  ※ source は使用しない
+  - action.yml から分割スクリプト呼び出し: bash "${GITHUB_ACTION_PATH}/scripts/<name>.sh" <args>
+  - 各ライブラリ関数の引数: readonly VAR="${1:-${VAR:?Error: VAR required}}"
+  - ユニット間の結果受け渡し: stdout を $() でキャプチャ
+  - 外部への副作用のみ GITHUB_ENV に書き込む: echo "VAR=value" >> "${GITHUB_ENV}"
+-->
+
+#### Unit Interaction Map
+
+```text
++------------------+     +------------------+     +------------------+
+|  validate-inputs | --> |  detect-arch     | --> |  setup-dirs      |
++------------------+     +------------------+     +------------------+
+                                                          |
+                                                          v
+                                                  +------------------+
+                                                  |  resolve-arch    |
+                                                  +------------------+
+                                                          |
+                                                          v
+                                                  +------------------+
+                                                  |  build-url       |
+                                                  +------------------+
+                                                          |
+                                                          v
+                                                  +------------------+
+                                                  |  download        |
+                                                  +------------------+
+                                                          |
+                                                          v
+                                                  +------------------+
+                                                  |  verify-checksum |
+                                                  +------------------+
+                                                          |
+                                                          v
+                                                  +------------------+
+                                                  |  extract-install |
+                                                  +------------------+
+                                                          |
+                                              (if: always())
+                                                          v
+                                                  +------------------+
+                                                  |  cleanup         |
+                                                  +------------------+
+```
+
+#### Data Flow Diagram
+
+```text
+[inputs: repo, tool-name, tool-version]
+          |
+          v
+  [validate-inputs] --失敗--> [エラー終了]
+          |
+          v
+  [detect-arch] --> ARCH_CANDIDATES: ["amd64","x64"] or ["arm64"]
+          |
+          v
+  [setup-dirs] --> BIN_DIR, TEMP_DIR (GITHUB_ENV/GITHUB_PATH 書き込み)
+          |
+          v
+  [resolve-arch] --curl --head -L 順次確認--> ARCH_SUFFIX
+          |         全候補失敗 --> [::error:: + exit 2]
+          v
+  [build-url] --> DOWNLOAD_URL, CHECKSUM_URL (stdout)
+          |
+          v
+  [download] --> TEMP_DIR/{tool}.tar.gz, checksums.txt
+          |
+          v
+  [verify-checksum] --不一致--> [エラー終了]
+          |
+          v
+  [extract-install] --> BIN_DIR/{tool-name} (mode: 755, PATH に追加済み)
+          |
+  (if: always())
+          v
+  [cleanup] --> TEMP_DIR 削除済み
+```
+
+### 2.4 Non-Goals
+
+> **Derivation**: 以下はすべて REQUIREMENTS Section "Out of Scope" に由来する。
+
+- zip など tar.gz 以外のアーカイブ形式への対応 ← REQ: Out of Scope #1
+- macOS・Windows runner への対応 ← REQ: Out of Scope #2
+- チェックサム検証のスキップオプション ← REQ: Out of Scope #3
+- GitHub Releases 以外のダウンロード元への対応 ← REQ: Out of Scope #4
+
+### 2.5 Behavioral Design Decisions
+
+| ID    | Decision                                                                                                 | Rationale                                                       | Affected Rules | Status           |
+| ----- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | -------------- | ---------------- |
+| DD-01 | arch 候補を複数持ち curl --head で存在確認する                                                           | リリースごとに `ARCH_SUFFIX` が統一されていないため             | R-004, R-004b  | Active           |
+| DD-02 | X64 の `ARCH_CANDIDATES` は ["amd64", "x64"] の順で試行する                                              | amd64 が一般的なため先に試行する                                | R-004          | Active           |
+| DD-03 | validate-environment の前提はコメント記載のみ                                                            | 責務分離・action の単純化のため                                 | R-001          | Active           |
+| DD-04 | 認証トークンなし（public repo のみ対応）                                                                 | スコープを明確に限定するため                                    | R-004, R-005   | Active           |
+| DD-05 | 関数ライブラリ式・複数ファイル構成（4ファイル）                                                          | 可読性・テスト容易性・責務分離のため                            | 全ユニット     | Active           |
+| DD-06 | スクリプト間インターフェースを関数呼び出しと同規則に統一する                                             | 実装形態（関数/スクリプト）によらず呼び出し規則を一貫させるため | 全ユニット     | Active           |
+| DD-07 | tool-version は X.Y.Z 形式の明示的なバージョン文字列のみ受け付ける。デフォルト値は action.yml が保持する | 再現可能なビルド保証（REQ-NF-002）・呼び出し元の利便性のため    | R-001          | Promoted → DR-07 |
+| DD-08 | checksums.txt のエントリ検索は grep -w による完全一致とする                                              | aglabo 参考実装との一貫性・単純さのため                         | R-006          | Promoted → DR-07 |
+| DD-09 | repo の有効形式を [a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+ パターンとして定義                                     | テスト可能性（REQ-NF-004）のため                                | R-001          | Promoted → DR-06 |
+
+### 2.6 Related Decision Records
+
+| DR-ID | Title                                                           | Phase         | Impact on This Spec                             |
+| ----- | --------------------------------------------------------------- | ------------- | ----------------------------------------------- |
+| DR-01 | アーキテクチャは runner.arch から自動検出                       | req           | detect-arch / resolve-arch の設計根拠           |
+| DR-02 | チェックサム検証は必須（スキップ不可）                          | req           | verify-checksum は常に実行                      |
+| DR-03 | Linux (tar.gz) のみ対応                                         | req           | extract-install の対象形式を限定                |
+| DR-04 | repo は owner/repo 形式で呼び出し元が明示                       | req           | validate-inputs の検証ルールを規定              |
+| DR-05 | 関数ライブラリ式の新規実装                                      | req           | 全ユニットの実装方針を規定                      |
+| DR-06 | 関数ライブラリ式実装・入力検証ルール・スクリプト間 I/F の規範化 | review-harden | R-001 の検証パターン確定・スクリプト間 I/F 統一 |
+| DR-07 | バージョン形式と checksums.txt 検索方式の確定                   | review-harden | R-001 の version 検証・R-006 の検索ロジック確定 |
+
+### 2.7 DD to DR Promotion Criteria
+
+> **Purpose**: DD → DR 昇格の判断基準。昇格は人間の判断による。
+
+**昇格を検討する条件:**
+
+1. **複数仕様への影響** — 複数のモジュールや仕様に影響する決定
+2. **アーキテクチャ上の重要性** — 将来の設計選択を制約する決定
+3. **重要な代替案の存在** — 複数の有効な選択肢が存在した
+4. **ステークホルダーへの可視性** — 外部レビューが必要な決定
+
+**DD のままにする条件:**
+
+- 本仕様のみに局所的な決定
+- 代替案が存在しない
+- 理由が文脈から自明
+
+---
+
+## 3. Behavioral Specification
+
+### 3.1 Input Domain
+
+- 入力: `repo`（`owner/repo` 形式）、`tool-name`（英数字・ハイフン）、`tool-version`（`X.Y.Z` 形式の明示的なバージョン文字列）
+- `tool-version` は呼び出し元が明示的に指定する。`latest`・`stable` などの特殊形式は受け付けない
+- `tool-version` のデフォルト値は `action.yml` の `inputs.tool-version.default` として定義する
+- 前提: `validate-environment` action が事前に実行済みであること
+
+<!-- impl-note: tool-version は "v" プレフィックスを normalize_version() で除去してから使用する -->
+
+### 3.2 Output Semantics
+
+- 成功: `tool-name` バイナリが PATH から実行可能な状態になる
+- 失敗: 各ユニットがエラーメッセージを所定の形式で出力しステップを非ゼロ終了する
+- 常時: cleanup ユニットが実行され、一時ディレクトリが削除される
+
+#### エラー出力規則
+
+既存の `validate-environment` action および `setup-tool` 参考スクリプトに統一した形式を採用する。
+
+| 種別             | 形式                 | 出力先          |
+| ---------------- | -------------------- | --------------- |
+| エラーメッセージ | `::error::<message>` | stderr（`>&2`） |
+| 成功メッセージ   | `✓ <message>`        | stdout          |
+| 進捗メッセージ   | `<message>`          | stdout          |
+
+exit code は処理フェーズごとに固定値を割り当てる:
+
+| exit code | 意味                       | 対応ユニット                             |
+| --------- | -------------------------- | ---------------------------------------- |
+| 0         | 成功                       | 全ユニット                               |
+| 1         | 入力検証エラー・一般エラー | validate-inputs, detect-arch, setup-dirs |
+| 2         | ダウンロード失敗           | resolve-arch, download                   |
+| 3         | チェックサム検証失敗       | verify-checksum                          |
+| 4         | 展開・配置失敗             | extract-install                          |
+
+<!-- impl-note: エラー出力は既存の validation.lib.sh の validate_symbol() と同じく
+  echo "::error::${field}: ${message}" >&2; return 1 パターンを使用する -->
+
+---
+
+## 4. Decision Rules
+
+評価はこの順序で実施しなければならない。順序の変更は禁止する。
+
+| Rule ID | Step | Condition / Action                                                                                                                                                                                                               | Outcome                                                        |
+| ------- | ---: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| R-001   |    1 | WHEN action が呼び出されたとき: repo が `[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+` に一致し、tool-name が非空、tool-version が `X.Y.Z` 形式（`latest` 等の特殊形式は不正）か。tool-version 未指定時は action.yml のデフォルト値を使用する | 不正 → `::error::` を stderr に出力して exit 1                 |
+| R-002   |    2 | WHEN R-001 が成功したとき: runner.arch が X64 か ARM64 か                                                                                                                                                                        | X64→["amd64","x64"] / ARM64→["arm64"] / 未知→exit 1            |
+| R-003   |    3 | WHEN R-002 が成功したとき: BIN_DIR（`${RUNNER_TEMP}/bin`）と TEMP_DIR（`mktemp -d`）を作成し GITHUB_ENV/GITHUB_PATH に書き込む                                                                                                   | 失敗 → `::error::` を stderr に出力して exit 1                 |
+| R-004   |    4 | WHEN R-003 が成功したとき: ARCH_CANDIDATES を順に curl --head -L で確認し、結果を stdout に出力する                                                                                                                              | 最初の 200 → ARCH_SUFFIX を stdout 出力 / 全失敗 → exit 2      |
+| R-004b  |    5 | WHEN R-004 が成功したとき: `ARCH_SUFFIX`・`repo`・`tool-name`・`tool-version` を入力として受け取り tar.gz URL と checksums.txt URL を stdout に出力する                                                                          | URL 文字列を stdout 出力                                       |
+| R-005   |    6 | WHEN R-004b が成功したとき: URL をパラメータとして受け取り tar.gz + checksums.txt をダウンロードする                                                                                                                             | 失敗 → `::error::` を stderr に出力して exit 2                 |
+| R-006   |    7 | WHEN R-005 が成功したとき: sha256sum でハッシュを検証する（checksums.txt を `grep -w` で完全一致検索）                                                                                                                           | エントリなし・不一致 → `::error::` を stderr に出力して exit 3 |
+| R-007   |    8 | WHEN R-006 が成功したとき: tar.gz を展開し `tool-name` に一致するバイナリを BIN_DIR に 755 で配置する                                                                                                                            | 一致なし・失敗 → `::error::` を stderr に出力して exit 4       |
+| R-008   |    9 | WHEN action の全ステップが終了したとき（成功・失敗を問わず）: TEMP_DIR が存在する場合はこれを削除する                                                                                                                            | 冪等（既に削除済みでも exit 0）                                |
+
+---
+
+## 5. Edge Cases
+
+| 入力・状態                                           | 振る舞い                                                  | REQ       | Rationale                                 |
+| ---------------------------------------------------- | --------------------------------------------------------- | --------- | ----------------------------------------- |
+| repo が `[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+` に不一致   | `::error::` を stderr に出力して exit 1（R-001）          | REQ-F-001 | 後続の URL 構築が不正になるため           |
+| tool-version に "v" プレフィックスあり               | 正規化して除去してから処理を継続                          | REQ-F-001 | バージョン文字列の統一のため              |
+| tool-version が "latest" など X.Y.Z 形式でない       | `::error::` を stderr に出力して exit 1（R-001）          | REQ-F-001 | 再現可能なビルドのため固定バージョン必須  |
+| runner.arch が X64/ARM64 以外                        | `::error::` を stderr に出力して exit 1（R-002）          | REQ-F-002 | 未知 arch への対応は Out of Scope         |
+| `ARCH_CANDIDATES`[0] が 404、[1] が 200              | [1] の `ARCH_SUFFIX` を採用して処理を継続                 | REQ-F-002 | DD-01・DD-02 の根拠                       |
+| `ARCH_CANDIDATES` の全候補が 404                     | `::error::` を stderr に出力して exit 2（R-004）          | REQ-F-003 | ダウンロード不可のため                    |
+| checksums.txt に対象ファイル名のエントリなし         | `::error::` を stderr に出力して exit 3（R-006）          | REQ-F-004 | 検証が不可能なため                        |
+| BIN_DIR に同名バイナリが既に存在                     | 上書きして処理を継続                                      | REQ-F-005 | 冪等性（REQ-NF-002）のため                |
+| tar.gz 内に tool-name と一致するバイナリが存在しない | `::error::` を stderr に出力して exit 4（R-007）          | REQ-F-005 | インストール対象が特定できないため        |
+| TEMP_DIR が cleanup 時に既に削除済み                 | 正常終了（冪等）                                          | REQ-F-006 | cleanup は always() で実行されるため      |
+| extract-install が失敗した後の cleanup               | cleanup は実行され TEMP_DIR を削除する                    | REQ-F-006 | if: always() による保証                   |
+| `curl --head -L` がタイムアウトする（全候補）        | 全候補失敗とみなし `::error::` を出力して exit 2（R-004） | REQ-F-003 | curl のデフォルトタイムアウト動作に委ねる |
+
+---
+
+## 6. Requirements Traceability
+
+| Requirement ID | Spec Rule            | Notes                                                  |
+| -------------- | -------------------- | ------------------------------------------------------ |
+| REQ-F-001      | R-001                | 入力値検証。repo は owner/repo 形式を検証              |
+| REQ-F-002      | R-002, R-004         | arch 検出は候補生成（R-002）+ 存在確認（R-004）の2段階 |
+| REQ-F-003      | R-004, R-004b, R-005 | arch 解決（R-004）→ URL 構築（R-004b）→ DL（R-005）    |
+| REQ-F-004      | R-006                | SHA256 検証は必須・スキップ不可                        |
+| REQ-F-005      | R-003, R-007         | setup-dirs（R-003）と extract-install（R-007）         |
+| REQ-F-006      | R-008                | if: always() で常に実行。冪等                          |
+| REQ-NF-001     | R-006, R-007         | SHA256 検証必須・パーミッション 755                    |
+| REQ-NF-002     | R-003, R-007, R-008  | 再実行時も同じ結果を保証                               |
+| REQ-NF-003     | DD-05                | 関数ライブラリ式・4ファイル構成                        |
+| REQ-NF-004     | DD-05                | 関数単位でのユニットテスト可能                         |
+| REQ-C-001      | 全ルール             | Linux ubuntu runner のみを対象                         |
+| REQ-C-002      | R-007                | tar.gz のみ展開対象                                    |
+| REQ-C-003      | R-006                | チェックサム検証はスキップ不可                         |
+| REQ-C-004      | R-005                | URL パターンを固定                                     |
+| REQ-C-005      | DD-05                | 関数ライブラリ式・複数ファイル構成                     |
+
+---
+
+## 7. Open Questions
+
+> **Status**: COMPLETE
+
+| #     | Question                                                               | Source        | Impact                                                           |
+| ----- | ---------------------------------------------------------------------- | ------------- | ---------------------------------------------------------------- |
+| ~~1~~ | ~~tool-version に "latest" などの動的な値を許容するか~~                | ~~REQ-F-001~~ | ~~解決済み: X.Y.Z 形式のみ受け付ける（DR-07）~~                  |
+| ~~2~~ | ~~checksums.txt のファイル名パターンがリリースごとに異なる場合の対処~~ | ~~REQ-F-004~~ | ~~解決済み: grep -w による完全一致検索（DR-07）~~                |
+| ~~3~~ | ~~resolve-arch の HTTP タイムアウト・リトライ回数の上限~~              | ~~REQ-F-003~~ | ~~解決済み: curl デフォルト動作に委ねる（Edge Cases 参照）~~     |
+| ~~4~~ | ~~エラー出力の統一規則が未定義~~                                       | ~~全ルール~~  | ~~解決済み: Section 3.2 エラー出力規則に統一フォーマットを定義~~ |
+| ~~5~~ | ~~build-url の Decision Rules への対応が欠落~~                         | ~~REQ-F-003~~ | ~~解決済み: R-004b として独立ルールを追加~~                      |
+| ~~6~~ | ~~tar.gz 内バイナリ名が tool-name と一致しない場合の振る舞いが未定義~~ | ~~REQ-F-005~~ | ~~解決済み: R-007 および Edge Cases に追記~~                     |
+
+---
+
+## 8. Change History
+
+| Date       | Version | Description                                                                                            |
+| ---------- | ------- | ------------------------------------------------------------------------------------------------------ |
+| 2026-06-07 | 1.0.0   | Initial specification                                                                                  |
+| 2026-06-07 | 1.1.0   | explore レビュー反映: エラー出力規則・build-url・バイナリ探索ロジック追加                              |
+| 2026-06-07 | 1.2.0   | harden レビュー反映: WHEN 条件明示・入力検証パターン確定・スクリプト間 I/F 統一・DR-06/07 追加         |
+| 2026-06-07 | 1.3.0   | fix レビュー反映: 用語統一・ASCII 図に build-url 追加・DD Affected Rules 修正・Open Questions COMPLETE |

--- a/docs/.deckrd/composite-action/setup-tool/tasks/tasks.md
+++ b/docs/.deckrd/composite-action/setup-tool/tasks/tasks.md
@@ -1,0 +1,507 @@
+---
+title: "Implementation Tasks"
+module: "composite-action/setup-tool"
+status: Active
+created: "2026-06-07 00:00:00"
+source: specifications.md
+---
+
+<!-- cspell:words rhysd rwxr invalidrepo -->
+
+<!-- textlint-disable
+  ja-technical-writing/sentence-length,
+  ja-technical-writing/max-comma -->
+<!-- markdownlint-disable no-duplicate-heading line-length -->
+
+> このドキュメントは specifications.md と implementation.md から導出した実装タスク一覧です。
+> 各タスクは単一の BDD テストケース（`it()` ブロック）に対応します。
+> 実施順序: **共通ライブラリ（T-01→T-02→T-03→T-04）→ Phase 1〜4（T-05〜T-13）**
+
+---
+
+## Task Summary
+
+| #  | Test Target                             | Scenarios | Cases | Status  |
+| -- | --------------------------------------- | --------- | ----- | ------- |
+| 1  | T-01: normalize_version                 | 2         | 5     | done    |
+| 2  | T-02: validate_symbol                   | 2         | 4     | done    |
+| 3  | T-03: validate-environment 移行検証     | 1         | 2     | done    |
+| 4  | T-04: setup-tool 共通ライブラリ移行検証 | 1         | 2     | done    |
+| 5  | T-05: setup_dirs                        | 4         | 6     | pending |
+| 6  | T-06: detect_arch                       | 3         | 4     | pending |
+| 7  | T-07: build_url                         | 2         | 2     | pending |
+| 8  | T-08: resolve_assets                    | 3         | 7     | pending |
+| 9  | T-09: download_tool                     | 2         | 4     | pending |
+| 10 | T-10: verify_checksum                   | 3         | 5     | pending |
+| 11 | T-11: extract_install                   | 3         | 5     | pending |
+| 12 | T-12: cleanup                           | 2         | 3     | pending |
+| 13 | T-13: setup-tool.sh                     | 4         | 7     | pending |
+
+---
+
+## T-01: normalize_version
+
+### [正常] Normal Cases
+
+#### T-01-01: v プレフィックスを除去する
+
+- [x] **T-01-01-01**: `v1.2.3` が `1.2.3` に正規化される
+  - Target: `normalize_version`
+  - Scenario: Given version=`v1.2.3`、When `normalize_version` を呼び出す
+  - Expected: Then stdout が `1.2.3` である
+
+- [x] **T-01-01-02**: `V1.2.3`（大文字V）も `1.2.3` に正規化される
+  - Target: `normalize_version`
+  - Scenario: Given version=`V1.2.3`、When `normalize_version` を呼び出す
+  - Expected: Then stdout が `1.2.3` である
+
+- [x] **T-01-01-03**: プレフィックスなしの `1.2.3` はそのまま出力される
+  - Target: `normalize_version`
+  - Scenario: Given version=`1.2.3`（プレフィックスなし）、When `normalize_version` を呼び出す
+  - Expected: Then stdout が `1.2.3` である
+
+### [異常] Error Cases
+
+#### T-01-02: 不正なバージョン形式の場合
+
+- [x] **T-01-02-01**: X.Y.Z 形式でないバージョンで exit 1 で失敗する
+  - Target: `normalize_version`
+  - Scenario: Given version=`latest`（不正形式）、When `normalize_version` を呼び出す
+  - Expected: Then exit 1 で終了する
+
+- [x] **T-01-02-02**: 空文字を渡したとき exit 1 で失敗する
+  - Target: `normalize_version`
+  - Scenario: Given version=``（空文字）、When `normalize_version` を呼び出す
+  - Expected: Then exit 1 で終了する
+
+---
+
+## T-02: validate_symbol
+
+### [正常] Normal Cases
+
+#### T-02-01: 値がパターンに一致する場合
+
+- [x] **T-02-01-01**: 有効な値でパターン一致のとき exit 0 で成功する
+  - Target: `validate_symbol`
+  - Scenario: Given value=`actionlint`・pattern=`[a-z][a-z0-9_-]*`、When `validate_symbol` を呼び出す
+  - Expected: Then exit 0 で正常終了する
+
+- [x] **T-02-01-02**: owner/repo 形式の値がパターンに一致する
+  - Target: `validate_symbol`
+  - Scenario: Given value=`rhysd/actionlint`・pattern=`[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+`、When `validate_symbol` を呼び出す
+  - Expected: Then exit 0 で正常終了する
+
+### [異常] Error Cases
+
+#### T-02-02: 値がパターンに不一致の場合
+
+- [x] **T-02-02-01**: パターン不一致のとき ::error:: を出力して exit 1 で失敗する
+  - Target: `validate_symbol`
+  - Scenario: Given value=`invalid value!`（不正文字含む）・pattern=`[a-z]+`、When `validate_symbol` を呼び出す
+  - Expected: Then `::error::` が stderr に出力されて exit 1 で終了する
+
+- [x] **T-02-02-02**: 空文字でパターン不一致のとき exit 1 で失敗する
+  - Target: `validate_symbol`
+  - Scenario: Given value=``（空文字）、When `validate_symbol` を呼び出す
+  - Expected: Then `::error::` が stderr に出力されて exit 1 で終了する
+
+---
+
+## T-03: validate-environment 共通ライブラリ移行検証
+
+> 付加タスク A-2 完了後の検証タスク。validate-environment の既存テストが GREEN を維持することを確認する。
+
+### [正常] Normal Cases
+
+#### T-03-01: 共通ライブラリ移行後も validate-environment の既存テストが通過する
+
+- [x] **T-03-01-01**: validate-apps の既存テストが共通ライブラリ移行後も GREEN である
+  - Target: `validate-environment/scripts/validate-apps.sh`
+  - Scenario: Given 共通ライブラリ（out_status・write_output）への移行が完了している、When `bash scripts/run-specs.sh .github/actions/validate-environment/scripts/__tests__` を実行する
+  - Expected: Then 全テストが GREEN で通過する
+
+- [x] **T-03-01-02**: validate-git-runner の既存テストが共通ライブラリ移行後も GREEN である
+  - Target: `validate-environment/scripts/validate-git-runner.sh`
+  - Scenario: Given 共通ライブラリ（check_env_var）への移行が完了している、When `bash scripts/run-specs.sh .github/actions/validate-environment/scripts/__tests__` を実行する
+  - Expected: Then 全テストが GREEN で通過する
+
+---
+
+## T-04: setup-tool 共通ライブラリ移行検証
+
+> 付加タスク A-3 完了後の検証タスク。setup-tool の既存ライブラリテストが GREEN を維持することを確認する。
+
+### [正常] Normal Cases
+
+#### T-04-01: 共通ライブラリ移行後も setup-tool の既存テストが通過する
+
+- [x] **T-04-01-01**: normalize_version のテストが共通ライブラリ移行後も GREEN である
+  - Target: `.github/actions/_libs/version.lib.sh`
+  - Scenario: Given normalize_version が共通 version.lib.sh に移行完了している、When `bash scripts/run-specs.sh .github/actions/setup-tool/scripts/__tests__` を実行する
+  - Expected: Then 全テストが GREEN で通過する
+
+- [x] **T-04-01-02**: validate_symbol のテストが共通ライブラリ移行後も GREEN である
+  - Target: `.github/actions/_libs/validation.lib.sh`
+  - Scenario: Given validate_symbol が共通 validation.lib.sh に移行完了している、When `bash scripts/run-specs.sh .github/actions/setup-tool/scripts/__tests__` を実行する
+  - Expected: Then 全テストが GREEN で通過する
+
+---
+
+## T-05: setup_dirs
+
+### [正常] Normal Cases
+
+#### T-05-01: RUNNER_TEMP が設定済みの状態で setup_dirs を呼び出す
+
+- [ ] **T-05-01-01**: BIN_DIR が `${RUNNER_TEMP}/bin` として作成される
+  - Target: `setup_dirs`
+  - Scenario: Given RUNNER_TEMP が設定済み、When `setup_dirs` を呼び出す
+  - Expected: Then `${RUNNER_TEMP}/bin` ディレクトリが存在する
+
+- [ ] **T-05-01-02**: TEMP_DIR が `mktemp -d` で動的生成される
+  - Target: `setup_dirs`
+  - Scenario: Given RUNNER_TEMP が設定済み、When `setup_dirs` を呼び出す
+  - Expected: Then TEMP_DIR が空でないパスとして設定されており、ディレクトリが存在する
+
+- [ ] **T-05-01-03**: BIN_DIR が GITHUB_PATH に書き込まれる
+  - Target: `setup_dirs`
+  - Scenario: Given GITHUB_PATH ファイルが存在する、When `setup_dirs` を呼び出す
+  - Expected: Then GITHUB_PATH ファイルに BIN_DIR のパスが追記されている
+
+- [ ] **T-05-01-04**: BIN_DIR と TEMP_DIR が GITHUB_ENV に書き込まれる
+  - Target: `setup_dirs`
+  - Scenario: Given GITHUB_ENV ファイルが存在する、When `setup_dirs` を呼び出す
+  - Expected: Then GITHUB_ENV に `BIN_DIR=...` と `TEMP_DIR=...` が追記されている
+
+### [異常] Error Cases
+
+#### T-05-02: RUNNER_TEMP が未設定の状態で setup_dirs を呼び出す
+
+- [ ] **T-05-02-01**: RUNNER_TEMP 未設定時に exit 1 で失敗する
+  - Target: `setup_dirs`
+  - Scenario: Given RUNNER_TEMP が未設定、When `setup_dirs` を呼び出す
+  - Expected: Then `::error::` が stderr に出力されて exit 1 で終了する
+
+### [エッジケース] Edge Cases
+
+#### T-05-03: GITHUB_ENV / GITHUB_PATH が未設定の場合
+
+- [ ] **T-05-03-01**: GITHUB_ENV が未設定でもディレクトリ作成は成功する
+  - Target: `setup_dirs`
+  - Scenario: Given GITHUB_ENV が空または `/dev/null` に設定されている（ローカルテスト環境）、When `setup_dirs` を呼び出す
+  - Expected: Then BIN_DIR・TEMP_DIR は作成され、GITHUB_ENV への書き込みは /dev/null に吸収されて exit 0 で終了する
+
+---
+
+## T-06: detect_arch
+
+### [正常] Normal Cases
+
+#### T-06-01: runner.arch が X64 の場合
+
+- [ ] **T-06-01-01**: RUNNER_ARCH=X64 のとき amd64 と x64 を1行1値で出力する
+  - Target: `detect_arch`
+  - Scenario: Given RUNNER_ARCH=X64、When `detect_arch` を呼び出す
+  - Expected: Then stdout の1行目が `amd64`、2行目が `x64` である
+
+#### T-06-02: runner.arch が ARM64 の場合
+
+- [ ] **T-06-02-01**: RUNNER_ARCH=ARM64 のとき arm64 を1行で出力する
+  - Target: `detect_arch`
+  - Scenario: Given RUNNER_ARCH=ARM64、When `detect_arch` を呼び出す
+  - Expected: Then stdout の1行目が `arm64` のみである
+
+### [異常] Error Cases
+
+#### T-06-03: runner.arch が未知の値の場合
+
+- [ ] **T-06-03-01**: 未知の RUNNER_ARCH で ::error:: を出力して exit 1 で失敗する
+  - Target: `detect_arch`
+  - Scenario: Given RUNNER_ARCH=MIPS（未知の値）、When `detect_arch` を呼び出す
+  - Expected: Then `::error::` が stderr に出力されて exit 1 で終了する
+
+- [ ] **T-06-03-02**: RUNNER_ARCH が未設定のとき exit 1 で失敗する
+  - Target: `detect_arch`
+  - Scenario: Given RUNNER_ARCH が空文字、When `detect_arch` を呼び出す
+  - Expected: Then `::error::` が stderr に出力されて exit 1 で終了する
+
+---
+
+## T-07: build_url
+
+### [正常] Normal Cases
+
+#### T-07-01: 有効な repo と tool-version で GitHub API URL を構築する
+
+- [ ] **T-07-01-01**: owner/repo 形式と normalize_version 適用済み version で正しい API URL が構築される
+  - Target: `build_url`
+  - Scenario: Given repo=`rhysd/actionlint`・version=`1.7.7`（normalize_version 適用済み・v なし）、When `build_url` を呼び出す
+  - Expected: Then stdout が `https://api.github.com/repos/rhysd/actionlint/releases/tags/v1.7.7` である
+
+### [エッジケース] Edge Cases
+
+#### T-07-02: tool-version に v プレフィックスが残っている場合（normalize_version 未適用の場合）
+
+- [ ] **T-07-02-01**: normalize_version 未適用の v 付き version を渡しても URL が vv 二重にならない
+  - Target: `build_url`
+  - Scenario: Given version=`v1.7.7`（normalize_version 未適用）、When `build_url` を呼び出す
+  - Expected: Then stdout の URL に `vv1.7.7` が含まれず、`v1.7.7` のパスとして構築される
+
+---
+
+## T-08: resolve_assets
+
+### [正常] Normal Cases
+
+#### T-08-01: アセット一覧に X64 向け tar.gz が含まれる場合
+
+- [ ] **T-08-01-01**: ARCH_CANDIDATES の最初の候補に一致する tar.gz URL が1行目に出力される
+  - Target: `resolve_assets`
+  - Scenario: Given GitHub API レスポンスに `actionlint_1.7.7_linux_amd64.tar.gz` が含まれる、When `resolve_assets` を ARCH_CANDIDATES=`[amd64,x64]` で呼び出す
+  - Expected: Then stdout の1行目が amd64 のダウンロード URL、3行目が `amd64` である
+
+- [ ] **T-08-01-02**: `checksums.txt` が存在する場合はそちらが CHECKSUM_URL として出力される
+  - Target: `resolve_assets`
+  - Scenario: Given アセット一覧に `checksums.txt` が含まれる、When `resolve_assets` を呼び出す
+  - Expected: Then stdout の2行目の URL に `checksums.txt` が含まれる
+
+#### T-08-02: checksums.txt が存在せず tool_version_checksums.txt がある場合
+
+- [ ] **T-08-02-01**: `{tool}_{version}_checksums.txt` 形式にフォールバックする
+  - Target: `resolve_assets`
+  - Scenario: Given `checksums.txt` がなく `actionlint_1.7.7_checksums.txt` がある、When `resolve_assets` を呼び出す
+  - Expected: Then stdout の2行目の URL に `actionlint_1.7.7_checksums.txt` が含まれる
+
+#### T-08-03: ARCH_CANDIDATES の第1候補が存在せず第2候補で一致する場合
+
+- [ ] **T-08-03-01**: amd64 がなく x64 がある場合に x64 が ARCH_SUFFIX として採用される
+  - Target: `resolve_assets`
+  - Scenario: Given アセット一覧に `linux_amd64.tar.gz` がなく `linux_x64.tar.gz` がある、When `resolve_assets` を ARCH_CANDIDATES=`[amd64,x64]` で呼び出す
+  - Expected: Then stdout の3行目が `x64` であり、1行目の URL に `x64` が含まれる
+
+### [異常] Error Cases
+
+#### T-08-04: ARCH_CANDIDATES がすべてアセット一覧に存在しない場合
+
+- [ ] **T-08-04-01**: 全候補が不一致のとき ::error:: を出力して exit 2 で失敗する
+  - Target: `resolve_assets`
+  - Scenario: Given アセット一覧に amd64・x64 どちらも存在しない、When `resolve_assets` を呼び出す
+  - Expected: Then `::error::` が stderr に出力されて exit 2 で終了する
+
+- [ ] **T-08-04-02**: GitHub API 呼び出し失敗時に exit 2 で失敗する
+  - Target: `resolve_assets`
+  - Scenario: Given curl が失敗する（API 接続不可）、When `resolve_assets` を呼び出す
+  - Expected: Then `::error::` が stderr に出力されて exit 2 で終了する
+
+- [ ] **T-08-04-03**: checksums.txt 候補が両方とも存在しない場合に exit 2 で失敗する
+  - Target: `resolve_assets`
+  - Scenario: Given tar.gz は存在するが checksums.txt 系ファイルがない、When `resolve_assets` を呼び出す
+  - Expected: Then `::error::` が stderr に出力されて exit 2 で終了する
+
+---
+
+## T-09: download_tool
+
+### [正常] Normal Cases
+
+#### T-09-01: 有効な URL で tar.gz と checksums.txt をダウンロードする
+
+- [ ] **T-09-01-01**: tar.gz が `${TOOL_NAME}.tar.gz` としてリネームされて TEMP_DIR に保存される
+  - Target: `download_tool`
+  - Scenario: Given DOWNLOAD_URL が有効、TEMP_DIR が存在する、When `download_tool` を呼び出す
+  - Expected: Then `${TEMP_DIR}/${TOOL_NAME}.tar.gz` が存在する
+
+- [ ] **T-09-01-02**: checksums.txt が TEMP_DIR に保存される
+  - Target: `download_tool`
+  - Scenario: Given CHECKSUM_URL が有効、When `download_tool` を呼び出す
+  - Expected: Then `${TEMP_DIR}/checksums.txt` が存在する
+
+### [異常] Error Cases
+
+#### T-09-02: curl ダウンロードが失敗する場合
+
+- [ ] **T-09-02-01**: tar.gz のダウンロード失敗時に ::error:: を出力して exit 2 で失敗する
+  - Target: `download_tool`
+  - Scenario: Given DOWNLOAD_URL が無効（404）、When `download_tool` を呼び出す
+  - Expected: Then `::error::` が stderr に出力されて exit 2 で終了する
+
+- [ ] **T-09-02-02**: checksums.txt のダウンロード失敗時に ::error:: を出力して exit 2 で失敗する
+  - Target: `download_tool`
+  - Scenario: Given CHECKSUM_URL が無効、When `download_tool` を呼び出す
+  - Expected: Then `::error::` が stderr に出力されて exit 2 で終了する
+
+---
+
+## T-10: verify_checksum
+
+### [正常] Normal Cases
+
+#### T-10-01: ハッシュが一致する場合
+
+- [ ] **T-10-01-01**: sha256sum が一致するとき exit 0 で成功する
+  - Target: `verify_checksum`
+  - Scenario: Given `${TOOL_NAME}.tar.gz` と checksums.txt のハッシュが一致する、When `verify_checksum` を呼び出す
+  - Expected: Then exit 0 で正常終了する
+
+### [異常] Error Cases
+
+#### T-10-02: checksums.txt にエントリが存在しない場合
+
+- [ ] **T-10-02-01**: 元ファイル名のエントリが grep -w で見つからないとき exit 3 で失敗する
+  - Target: `verify_checksum`
+  - Scenario: Given checksums.txt に `{tool}_{ver}_linux_{arch}.tar.gz` のエントリがない、When `verify_checksum` を呼び出す
+  - Expected: Then `::error::` が stderr に出力されて exit 3 で終了する
+
+#### T-10-03: ハッシュが一致しない場合
+
+- [ ] **T-10-03-01**: sha256sum が不一致のとき ::error:: を出力して exit 3 で失敗する
+  - Target: `verify_checksum`
+  - Scenario: Given ダウンロードファイルが破損（ハッシュ不一致）、When `verify_checksum` を呼び出す
+  - Expected: Then `::error::` が stderr に出力されて exit 3 で終了する
+
+### [エッジケース] Edge Cases
+
+#### T-10-04: 検索キーが元ファイル名形式であることの確認
+
+- [ ] **T-10-04-01**: grep の検索キーがリネーム前の形式（tool_ver_linux_arch.tar.gz）である
+  - Target: `verify_checksum`
+  - Scenario: Given checksums.txt に `actionlint_1.7.7_linux_amd64.tar.gz` のエントリがある、When `verify_checksum` を tool=actionlint・ver=1.7.7・arch=amd64 で呼び出す
+  - Expected: Then エントリが見つかり検証が成功する
+
+- [ ] **T-10-04-02**: sha256sum の対象がリネーム後の ${TOOL_NAME}.tar.gz である
+  - Target: `verify_checksum`
+  - Scenario: Given TEMP_DIR に `actionlint.tar.gz`（リネーム後）が存在する、When `verify_checksum` を呼び出す
+  - Expected: Then `actionlint.tar.gz` のハッシュが検証対象となる
+
+---
+
+## T-11: extract_install
+
+### [正常] Normal Cases
+
+#### T-11-01: tool-name に一致するバイナリが tar.gz 内に存在する場合
+
+- [ ] **T-11-01-01**: バイナリが BIN_DIR に配置される
+  - Target: `extract_install`
+  - Scenario: Given `${TOOL_NAME}.tar.gz` 内に tool-name と一致するバイナリが存在する、When `extract_install` を呼び出す
+  - Expected: Then `${BIN_DIR}/${TOOL_NAME}` が存在する
+
+- [ ] **T-11-01-02**: 配置されたバイナリのパーミッションが 755 である
+  - Target: `extract_install`
+  - Scenario: Given バイナリが BIN_DIR に配置された、When パーミッションを確認する
+  - Expected: Then ファイルのパーミッションが 755（rwxr-xr-x）である
+
+### [異常] Error Cases
+
+#### T-11-02: tar.gz 内に tool-name に一致するバイナリが存在しない場合
+
+- [ ] **T-11-02-01**: バイナリ不一致のとき ::error:: を出力して exit 4 で失敗する
+  - Target: `extract_install`
+  - Scenario: Given tar.gz 内に tool-name と一致するファイルがない、When `extract_install` を呼び出す
+  - Expected: Then `::error::` が stderr に出力されて exit 4 で終了する
+
+#### T-11-03: tar 展開が失敗する場合
+
+- [ ] **T-11-03-01**: tar 失敗時に ::error:: を出力して exit 4 で失敗する
+  - Target: `extract_install`
+  - Scenario: Given `${TOOL_NAME}.tar.gz` が破損している、When `extract_install` を呼び出す
+  - Expected: Then `::error::` が stderr に出力されて exit 4 で終了する
+
+### [エッジケース] Edge Cases
+
+#### T-11-04: BIN_DIR に同名バイナリが既に存在する場合
+
+- [ ] **T-11-04-01**: 既存バイナリを上書きして exit 0 で成功する（冪等性）
+  - Target: `extract_install`
+  - Scenario: Given BIN_DIR に既に同名バイナリが存在する、When `extract_install` を呼び出す
+  - Expected: Then 上書きされて exit 0 で正常終了する
+
+---
+
+## T-12: cleanup
+
+### [正常] Normal Cases
+
+#### T-12-01: TEMP_DIR が存在する状態で cleanup を呼び出す
+
+- [ ] **T-12-01-01**: TEMP_DIR が削除される
+  - Target: `cleanup`
+  - Scenario: Given TEMP_DIR が存在する、When `cleanup "${TEMP_DIR}"` を呼び出す
+  - Expected: Then TEMP_DIR が存在しない
+
+- [ ] **T-12-01-02**: 成功メッセージが stdout に出力される
+  - Target: `cleanup`
+  - Scenario: Given TEMP_DIR が存在する、When `cleanup "${TEMP_DIR}"` を呼び出す
+  - Expected: Then stdout に `✓ Cleanup completed` が出力される
+
+### [エッジケース] Edge Cases
+
+#### T-12-02: TEMP_DIR が既に削除済みの場合
+
+- [ ] **T-12-02-01**: 削除済みの場合も exit 0 で成功する（冪等性）
+  - Target: `cleanup`
+  - Scenario: Given TEMP_DIR が既に存在しない、When `cleanup "${TEMP_DIR}"` を呼び出す
+  - Expected: Then exit 0 で正常終了する
+
+---
+
+## T-13: setup-tool.sh
+
+### [正常] Normal Cases
+
+#### T-13-01: 全関数が正常終了する場合
+
+- [ ] **T-13-01-01**: 全関数が定義された順序で呼び出される
+  - Target: `setup-tool.sh`
+  - Scenario: Given 全ライブラリ関数がモック化されて正常終了する、When `setup-tool.sh` を実行する
+  - Expected: Then normalize_version → validate_inputs → setup_dirs → detect_arch → resolve_assets → download_tool → verify_checksum → extract_install の順で呼び出される
+
+- [ ] **T-13-01-02**: 正常終了時に exit 0 で終了する
+  - Target: `setup-tool.sh`
+  - Scenario: Given 全関数が正常終了する、When `setup-tool.sh` を実行する
+  - Expected: Then exit 0 で終了する
+
+### [異常] Error Cases
+
+#### T-13-02: 入力検証が失敗する場合
+
+- [ ] **T-13-02-01**: repo が owner/repo 形式でないとき exit 1 で終了する
+  - Target: `setup-tool.sh`
+  - Scenario: Given REPO=`invalidrepo`（スラッシュなし）、When `setup-tool.sh` を実行する
+  - Expected: Then `::error::` が stderr に出力されて exit 1 で終了する
+
+- [ ] **T-13-02-02**: tool-version が X.Y.Z 形式でないとき exit 1 で終了する
+  - Target: `setup-tool.sh`
+  - Scenario: Given TOOL_VERSION=`latest`（不正形式）、When `setup-tool.sh` を実行する
+  - Expected: Then `::error::` が stderr に出力されて exit 1 で終了する
+
+#### T-13-03: 中間ステップが失敗する場合
+
+- [ ] **T-13-03-01**: resolve_assets 失敗時に exit 2 で終了する
+  - Target: `setup-tool.sh`
+  - Scenario: Given resolve_assets が exit 2 で失敗するようにモック化されている、When `setup-tool.sh` を実行する
+  - Expected: Then exit 2 で終了する
+
+- [ ] **T-13-03-02**: verify_checksum 失敗時に exit 3 で終了する
+  - Target: `setup-tool.sh`
+  - Scenario: Given verify_checksum が exit 3 で失敗するようにモック化されている、When `setup-tool.sh` を実行する
+  - Expected: Then exit 3 で終了する
+
+### [エッジケース] Edge Cases
+
+#### T-13-04: cleanup が必ず実行されることの確認
+
+- [ ] **T-13-04-01**: 中間ステップ失敗後も trap により cleanup が実行される
+  - Target: `setup-tool.sh`
+  - Scenario: Given download_tool が exit 2 で失敗する、When `setup-tool.sh` を実行する
+  - Expected: Then `cleanup "${TEMP_DIR}"` が EXIT trap により実行される
+
+---
+
+<!--
+Task ID Format: T-<TestTarget>-<Scenario>-<Case>
+- TestTarget: 2-digit (01, 02, ...)
+- Scenario: 2-digit (01, 02, ...)
+- Case: 2-digit (01, 02, ...)
+-->

--- a/runners/__tests__/unit/get-filelist.unit.spec.sh
+++ b/runners/__tests__/unit/get-filelist.unit.spec.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# shellcheck shell=bash
+# shellcheck disable=SC2034,SC2154
+
+# Test suite for get_filelist() function
+# Module: runners
+# Target: runners/libs/get-filelist.lib.sh
+
+Describe 'get_filelist()'
+  # --execdir @specfile → cwd is runners/__tests__/unit/
+  Include ../../libs/get-filelist.lib.sh
+
+  # ─── Internal Helpers
+
+  setup_tree() {
+    _FL_TMPDIR=$(mktemp -d)
+    mkdir -p "${_FL_TMPDIR}/.github/actions/_libs/__tests__/unit"
+    touch "${_FL_TMPDIR}/.github/actions/_libs/__tests__/unit/foo.unit.spec.sh"
+    mkdir -p "${_FL_TMPDIR}/other/__tests__/unit"
+    touch "${_FL_TMPDIR}/other/__tests__/unit/bar.unit.spec.sh"
+  }
+
+  teardown_tree() {
+    if [[ -d "${_FL_TMPDIR:-}" ]]; then
+      rm -rf "${_FL_TMPDIR}"
+    fi
+    unset _FL_TMPDIR
+  }
+
+  BeforeEach 'setup_tree'
+  AfterEach 'teardown_tree'
+
+  # ─── T-01-01: ./ なしのパスフィルタで一致する
+
+  Describe 'Given: .github/actions/_libs/__tests__/unit/foo.unit.spec.sh が存在'
+    Describe 'When: get_filelist root "*.spec.sh" ".github/actions/_libs" を呼ぶ'
+      Describe 'Then: T-01-01 - foo.unit.spec.sh が出力に含まれ bar は含まれない'
+        It 'includes foo.unit.spec.sh with path filter (no leading ./)'
+          When call get_filelist "$_FL_TMPDIR" "*.spec.sh" ".github/actions/_libs"
+          The output should include "foo.unit.spec.sh"
+          The status should equal 0
+        End
+
+        It 'excludes bar.unit.spec.sh with path filter (no leading ./)'
+          When call get_filelist "$_FL_TMPDIR" "*.spec.sh" ".github/actions/_libs"
+          The output should not include "bar.unit.spec.sh"
+          The status should equal 0
+        End
+      End
+    End
+  End
+
+  # ─── T-01-02: ./ あり（leading ./）のパスフィルタでも一致する
+
+  Describe 'Given: .github/actions/_libs/__tests__/unit/foo.unit.spec.sh が存在'
+    Describe 'When: get_filelist root "*.spec.sh" "./.github/actions/_libs" (leading ./) を呼ぶ'
+      Describe 'Then: T-01-02 - foo.unit.spec.sh が出力に含まれ bar は含まれない'
+        It 'includes foo.unit.spec.sh with path filter (with leading ./)'
+          When call get_filelist "$_FL_TMPDIR" "*.spec.sh" "./.github/actions/_libs"
+          The output should include "foo.unit.spec.sh"
+          The status should equal 0
+        End
+
+        It 'excludes bar.unit.spec.sh with path filter (with leading ./)'
+          When call get_filelist "$_FL_TMPDIR" "*.spec.sh" "./.github/actions/_libs"
+          The output should not include "bar.unit.spec.sh"
+          The status should equal 0
+        End
+      End
+    End
+  End
+
+End

--- a/runners/libs/get-filelist.lib.sh
+++ b/runners/libs/get-filelist.lib.sh
@@ -75,10 +75,12 @@ get_filelist() {
   local __f __norm
   for __f in "$@"; do
     __norm=$(normalize_path "$__f")
+    # Strip leading ./ so filter matches rg output (which has no ./ prefix)
+    __norm="${__norm#./}"
     if [[ "$__norm" == */* ]]; then
       __filters+=("$__norm")
     else
-      __filters+=("$(args_to_filter "$__f")")
+      __filters+=("$(args_to_filter "$__norm")")
     fi
   done
 

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -16,14 +16,14 @@ set -euo pipefail
 # @return 1 If not in CI environment
 is_ci_environment() {
   [[ -n "${CI:-}" ]] ||               # Generic CI
-  [[ -n "${GITHUB_ACTIONS:-}" ]] ||   # GitHub Actions
-  [[ -n "${GITLAB_CI:-}" ]] ||        # GitLab CI
-  [[ -n "${CIRCLECI:-}" ]] ||         # CircleCI
-  [[ -n "${JENKINS_HOME:-}" ]] ||     # Jenkins
-  [[ -n "${TRAVIS:-}" ]] ||           # Travis CI
-  [[ -n "${BUILDKITE:-}" ]] ||        # Buildkite
-  [[ -n "${DRONE:-}" ]] ||            # Drone CI
-  [[ -n "${TF_BUILD:-}" ]]            # Azure Pipelines
+    [[ -n "${GITHUB_ACTIONS:-}" ]] || # GitHub Actions
+    [[ -n "${GITLAB_CI:-}" ]] ||      # GitLab CI
+    [[ -n "${CIRCLECI:-}" ]] ||       # CircleCI
+    [[ -n "${JENKINS_HOME:-}" ]] ||   # Jenkins
+    [[ -n "${TRAVIS:-}" ]] ||         # Travis CI
+    [[ -n "${BUILDKITE:-}" ]] ||      # Buildkite
+    [[ -n "${DRONE:-}" ]] ||          # Drone CI
+    [[ -n "${TF_BUILD:-}" ]]          # Azure Pipelines
 }
 
 ##
@@ -53,7 +53,6 @@ main() {
     echo "CI environment detected. Skipping dev tools install."
     return 0
   fi
-
 
   # Install lefthook
   if is_lefthook_installed; then


### PR DESCRIPTION
## Overview

**Summary**
Adds Deckrd design documents for the setup-tool Composite Action, fixes a leading `./` bug in `get_filelist`, and adds unit tests for the library.

**Background / Motivation**
The setup-tool Composite Action lacked structured design documentation. This PR introduces requirements, specifications, implementation plan, and task list under the Deckrd framework. A path normalization bug in `get_filelist` was discovered during this work and fixed alongside its unit tests.

## Changes

### Core Changes

- `runners/libs/get-filelist.lib.sh` — strip leading `./` from the value returned by `normalize_path`
- `docs/.deckrd/composite-action/setup-tool/requirements/requirements.md` — redesigned and simplified requirements
- `docs/.deckrd/composite-action/setup-tool/specifications/specifications.md` — added design specification
- `docs/.deckrd/composite-action/setup-tool/implementation/implementation.md` — added implementation plan
- `docs/.deckrd/composite-action/setup-tool/tasks/tasks.md` — defined implementation task list

### Test Updates

- `runners/__tests__/unit/get-filelist.unit.spec.sh` — added unit spec for `get_filelist` library

### Removed

N/A

## Change Type (optional)

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Related to #42

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [x] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

Style fixes are also included:
- `scripts/setup-dev-env.sh` — fix indentation
- `.github/actions/setup-tool/scripts/setup-directories.sh` — remove extra space after redirect
