### PR TITLE
ci(workflows/scan-betterleaks): add reusable betterleaks secret scanning workflow

### DIFF
--- a/.github/workflows/ci-scan-betterleaks.yml
+++ b/.github/workflows/ci-scan-betterleaks.yml
@@ -1,0 +1,98 @@
+# src: ./.github/workflows/ci-scan-betterleaks.yml
+# @(#) : Reusable workflow for secret scanning with betterleaks
+#
+# Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+name: "CI Scan Betterleaks"
+
+# Minimal permissions following security best practices
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      betterleaks-version:
+        description: "Version of betterleaks to install"
+        required: false
+        default: "1.4.1"
+        type: string
+      config-repo:
+        description: "Repository that contains the betterleaks config"
+        required: false
+        default: "aglabo/.github"
+        type: string
+      fetch-depth:
+        description: "Git history depth to fetch (0 for full history)"
+        required: false
+        default: 50
+        type: number
+
+jobs:
+  scan-betterleaks:
+    name: Betterleaks Secret Scan
+    runs-on: ubuntu-slim
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout target repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: ${{ inputs.fetch-depth }}
+          persist-credentials: false
+
+      - name: Validate environment
+        id: env-validation
+        uses: ./.github/actions/validate-environment
+        with:
+          actions-type: read
+
+      - name: Install betterleaks
+        id: tool-install
+        if: steps.env-validation.outcome == 'success'
+        uses: ./.github/actions/setup-tool
+        with:
+          repo: betterleaks/betterleaks
+          tool-version: ${{ inputs.betterleaks-version }}
+
+      - name: Checkout betterleaks config
+        id: config-checkout
+        if: steps.tool-install.outcome == 'success'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.config-repo }}
+          path: shared
+          persist-credentials: false
+
+      - name: Prepare report directory
+        id: prepare-report
+        if: steps.config-checkout.outcome == 'success'
+        run: mkdir -p .github/report
+
+      - name: Run betterleaks scan
+        id: scan-execute
+        if: steps.prepare-report.outcome == 'success'
+        run: |
+          set +e
+          betterleaks git . \
+            --config shared/configs/betterleaks.toml \
+            --report-path=.github/report/betterleaks-report.json \
+            --exit-code=1 \
+            --verbose
+          betterleaks_status=$?
+          set -e
+          echo "status=${betterleaks_status}" >> "$GITHUB_OUTPUT"
+          exit "${betterleaks_status}"
+
+      - name: Upload betterleaks report
+        id: upload-report
+        if: failure() && steps.scan-execute.outputs.status != '0'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: betterleaks-report
+          path: .github/report/betterleaks-report.json
+          retention-days: 30

--- a/.github/workflows/ci-scan-secrets.yml
+++ b/.github/workflows/ci-scan-secrets.yml
@@ -24,8 +24,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  scan-gitleaks:
-    name: Gitleaks Secret Scan
+  scan-betterleaks:
+    name: Betterleaks Secret Scan
     permissions:
       contents: read
-    uses: aglabo/.github/.github/workflows/ci-common-scan-gitleaks.yml@38070c03acff350b4c8f46d684781052b70c0e58 # r1.1.2
+    uses: ./.github/workflows/ci-scan-betterleaks.yml

--- a/configs/ghalint.yaml
+++ b/configs/ghalint.yaml
@@ -10,3 +10,4 @@
 # Exclude specific policies if needed
 # excludes:
 # Allow version tags for reusable workflow calls instead of SHA pinning
+excludes: []

--- a/docs/.deckrd/reusable-workflows/betterleaks/implementation/implementation.md
+++ b/docs/.deckrd/reusable-workflows/betterleaks/implementation/implementation.md
@@ -1,0 +1,148 @@
+---
+title: "Implementation Plan: Betterleaks Reusable Workflow"
+based-on: specifications.md v1.1
+status: Draft
+---
+
+<!-- markdownlint-disable line-length -->
+
+## 1. Overview
+
+### 1.1 Purpose
+
+This implementation plan delivers a reusable GitHub Actions workflow for running Betterleaks scans from caller repositories. The workflow will be added at `.github/workflows/ci-scan-betterleaks.yml` and will support both reusable invocation through `workflow_call` and manual execution through `workflow_dispatch`.
+
+The workflow implements the following behavioral units in sequence:
+
+- `workflow-skeleton`
+- `env-validation-step`
+- `target-checkout-step` (with fetch-depth and persist-credentials)
+- `tool-install-step`
+- `config-checkout-step`
+- `prepare-report-step`
+- `scan-execute-step` (with report output and exit-code capture)
+- `upload-report-step` (on failure only)
+
+The workflow will enforce read-only repository access with `contents: read` at both the top-level workflow permissions block and the job-level permissions block.
+
+### 1.2 Reference
+
+- Prior Art / Reference PR: none
+- Specifications: specifications.md
+- Output workflow file: `.github/workflows/ci-scan-betterleaks.yml`
+
+## 2. Implementation Plan
+
+### Phase 1: Reusable Workflow YAML
+
+#### Commit 1: ci(workflows): add betterleaks reusable workflow
+
+- Create `.github/workflows/ci-scan-betterleaks.yml`.
+
+- Add the reusable workflow skeleton:
+  -- Set `name` to a descriptive Betterleaks reusable workflow name.
+  -- Add top-level `permissions`.
+  -- Set `permissions.contents` to `read`.
+  -- Add a single job for the Betterleaks scan.
+  -- Add job-level `permissions`.
+  -- Set job-level `permissions.contents` to `read`.
+  -- Set `runs-on` to `ubuntu-latest`.
+
+- Add triggers under `on`:
+  -- Add `workflow_call`.
+  -- Add `workflow_dispatch`.
+  -- Define matching inputs for both triggers.
+
+- Add input `betterleaks-version`:
+  -- Define under `on.workflow_call.inputs` and `on.workflow_dispatch.inputs`.
+  -- Set `required: false`.
+  -- Set `default: "1.4.1"` (compatible with betterleaks >= v1.0.0 and gitleaks >= v8.25.0).
+  -- Reference as `${{ inputs.betterleaks-version }}`.
+
+- Add input `config-repo`:
+  -- Define under `on.workflow_call.inputs` and `on.workflow_dispatch.inputs`.
+  -- Set `required: false`.
+  -- Set `default: aglabo/.github`.
+  -- Reference as `${{ inputs.config-repo }}`.
+
+- Add input `fetch-depth`:
+  -- Define under `on.workflow_call.inputs` and `on.workflow_dispatch.inputs`.
+  -- Set `required: false`.
+  -- Set `type: number`.
+  -- Set `default: 1` (latest commit only; use 0 for full history).
+  -- Reference as `${{ inputs.fetch-depth }}`.
+
+- Add step ID `env-validation` as the first step:
+  -- Use the local validate-environment composite action at path `.github/actions/validate-environment`.
+  -- Set `with.actions-type: read`.
+  -- Do not add an `if` condition to this first step.
+  -- Exposes `steps.env-validation.outputs.runner-status`.
+
+- Add step ID `target-checkout` after `env-validation`:
+  -- Use `actions/checkout`.
+  -- Do not set `path` (checks out caller repository to workspace root).
+  -- Set `with.fetch-depth: ${{ inputs.fetch-depth }}`.
+  -- Set `with.persist-credentials: false`.
+  -- Add `if: steps.env-validation.outcome == 'success'`.
+
+- Add step ID `tool-install` after `target-checkout`:
+  -- Use the local setup-tool composite action at path `.github/actions/setup-tool`.
+  -- Set `with.repo: betterleaks/betterleaks`.
+  -- Set `with.tool-version: ${{ inputs.betterleaks-version }}`.
+  -- Add `if: steps.target-checkout.outcome == 'success'`.
+
+- Add step ID `config-checkout` after `tool-install`:
+  -- Use `actions/checkout`.
+  -- Set `with.repository: ${{ inputs.config-repo }}`.
+  -- Set `with.path: shared`.
+  -- Do NOT set `with.ref` (check out default branch).
+  -- Add `if: steps.tool-install.outcome == 'success'`.
+
+- Add step ID `prepare-report` after `config-checkout`:
+  -- Use a shell `run` step: `mkdir -p .github/report`.
+  -- Add `if: steps.config-checkout.outcome == 'success'`.
+
+- Add step ID `scan-execute` after `prepare-report`:
+  -- Use a shell `run` step with `set +e` / `set -e` pattern to capture exit code.
+  -- Run betterleaks with:
+  `betterleaks protect --config shared/configs/betterleaks.toml --report-path=.github/report/betterleaks-report.json --exit-code=1 --verbose`
+  -- Capture exit code into `$GITHUB_OUTPUT` as `status`.
+  -- Re-exit with the captured exit code so the step fails on non-zero.
+  -- Add `if: steps.prepare-report.outcome == 'success'`.
+  -- Do not add `continue-on-error`.
+
+- Add step ID `upload-report` after `scan-execute`:
+  -- Use `actions/upload-artifact`.
+  -- Set `if: failure() && steps.scan-execute.outputs.status != '0'`.
+  -- Set `with.name: betterleaks-report`.
+  -- Set `with.path: .github/report/betterleaks-report.json`.
+  -- Set `with.retention-days: 30`.
+
+- Final step order and gating summary:
+  -- `env-validation` — no if condition
+  -- `target-checkout` — `if: steps.env-validation.outcome == 'success'`
+  -- `tool-install` — `if: steps.target-checkout.outcome == 'success'`
+  -- `config-checkout` — `if: steps.tool-install.outcome == 'success'`
+  -- `prepare-report` — `if: steps.config-checkout.outcome == 'success'`
+  -- `scan-execute` — `if: steps.prepare-report.outcome == 'success'`
+  -- `upload-report` — `if: failure() && steps.scan-execute.outputs.status != '0'`
+
+- Expected behavior after this commit:
+  -- Callable via `workflow_call` or `workflow_dispatch`.
+  -- Validates the environment for read-only actions usage.
+  -- Checks out the caller repository with configurable fetch-depth (default: 1).
+  -- Installs Betterleaks from `betterleaks/betterleaks` using the configured version.
+  -- Checks out `${{ inputs.config-repo }}` (default branch) into `shared/`.
+  -- Creates `.github/report/` directory before scanning.
+  -- Runs Betterleaks with `shared/configs/betterleaks.toml` and writes report to `.github/report/betterleaks-report.json`.
+  -- Fails immediately when Betterleaks reports a non-zero exit.
+  -- Uploads the report artifact `betterleaks-report` only when scan fails.
+  -- Operates with `contents: read` at both top-level and job-level.
+
+## 3. Change History
+
+| Date       | Version | Description                                                                         |
+| ---------- | ------- | ----------------------------------------------------------------------------------- |
+| 2026-06-12 | 1.2     | Add fetch-depth input, prepare-report step, report output, upload-report on failure |
+| 2026-06-12 | 1.1     | Set default betterleaks version to `1.4.1`                                          |
+| 2026-06-12 | 1.0     | Initial implementation plan                                                         |

--- a/docs/.deckrd/reusable-workflows/betterleaks/requirements/requirements.md
+++ b/docs/.deckrd/reusable-workflows/betterleaks/requirements/requirements.md
@@ -1,0 +1,431 @@
+---
+title: "Requirements: Betterleaks Reusable Workflow"
+module: "reusable-workflows/betterleaks"
+status: Draft
+version: 1.0
+created: "2026-06-12"
+---
+
+> **Normative Statement**
+> This document defines binding requirements.
+> Implementations MUST conform to this document.
+> RFC 2119 keywords apply to this document only.
+
+## 1. Overview
+
+### 1.1 Purpose
+
+This document defines the requirements for an independent reusable GitHub Actions workflow that performs betterleaks-based secret scanning without depending on the external `aglabo/.github` reusable workflow version `r1.1.2`. The workflow provides both reusable and manual execution paths, validates the runner environment before scanning, installs the configured betterleaks version through the local setup action, checks out a user-configurable configuration repository (defaulting to `aglabo/.github`) to obtain the betterleaks scan configuration, and fails immediately when secret scanning detects a failure.
+
+### 1.2 Scope
+
+- Provide a reusable GitHub Actions workflow for betterleaks secret scanning.
+- Support `workflow_call` execution from caller workflows.
+- Support `workflow_dispatch` manual execution.
+- Validate the GitHub Actions environment before tool setup and scan execution.
+- Install betterleaks through the local `setup-tool` action.
+- Allow the betterleaks version to be configured through an input parameter with a default value.
+- Allow the configuration repository to be specified via an input parameter (default: `aglabo/.github`).
+- Allow the git fetch depth to be configured via an input parameter (default: 1, latest commit only).
+- Checkout the specified configuration repository to access the betterleaks configuration.
+- Run betterleaks using `shared/configs/betterleaks.toml` from the checked-out configuration repository.
+- Output the scan result as a JSON report file.
+- Upload the scan report as a workflow artifact when a violation is detected.
+- Fail the workflow immediately when betterleaks returns a non-zero exit code.
+
+**Out of Scope**: Implementing or modifying the betterleaks tool itself; changing the local `validate-environment` action; changing the local `setup-tool` action; managing findings suppression policy; supporting non-Ubuntu runners; using the local `configs/betterleaks.toml` as the workflow scan configuration; making the config-repo checkout directory or branch configurable by callers.
+
+## 2. Context
+
+- Target Environment: GitHub Actions (ubuntu-latest runner)
+- Related Components:
+  - `reusable-workflows/betterleaks`
+  - Local `validate-environment` action `v0.1.1`
+  - Local `setup-tool` action
+  - `aglabo/.github` repository
+  - `global/configs/betterleaks.toml`
+  - betterleaks CLI
+  - Caller workflows using `workflow_call`
+  - Manual users using `workflow_dispatch`
+- Assumptions:
+  - The workflow executes on `ubuntu-latest`.
+  - The workflow has `contents: read` permission.
+  - The caller repository is checked out or otherwise available to the scan job before betterleaks execution.
+  - The configuration repository specified by the input parameter is readable by the workflow.
+  - The betterleaks configuration exists at `global/configs/betterleaks.toml` in the default branch of the configuration repository.
+  - The local `setup-tool` action can install betterleaks when passed `repo` and `tool-version`.
+  - The configured betterleaks version is compatible with the shared configuration.
+  - The shared configuration requires betterleaks minimum version `v1.0.0` and gitleaks minimum version `v8.25.0`.
+
+### System Context Diagram
+
+```text
++-------------------+        +---------------------+
+| Caller Workflow   |        | Manual User         |
+| workflow_call     |        | workflow_dispatch   |
++---------+---------+        +----------+----------+
+          |                             |
+          +-------------+---------------+
+                        |
+                        v
+        +---------------------------------------+
+        | Betterleaks Reusable Workflow         |
+        | runner: ubuntu-latest                 |
+        | permissions: contents: read           |
+        +-------------------+-------------------+
+                            |
+                            v
+        +---------------------------------------+
+        | validate-environment action v0.1.1    |
+        | validates runner, permissions, apps   |
+        +-------------------+-------------------+
+                            |
+                            v
+        +---------------------------------------+
+        | setup-tool action                     |
+        | installs configured betterleaks       |
+        +-------------------+-------------------+
+                            |
+                            v
+        +---------------------------------------+
+        | Checkout config-repo (default:        |
+        | aglabo/.github) into shared/          |
+        +-------------------+-------------------+
+                            |
+                            v
+        +---------------------------------------+
+        | betterleaks protect                   |
+        | --config shared/global/configs/       |
+        |          betterleaks.toml             |
+        +-------------------+-------------------+
+                            |
+              +-------------+-------------+
+              |                           |
+              v                           v
+   +---------------------+     +----------------------+
+   | Exit code 0         |     | Non-zero exit code   |
+   | Workflow passes     |     | Workflow fails fast  |
+   +---------------------+     +----------------------+
+```
+
+## 3. Design Decisions (Summary)
+
+| ID    | Decision                                                                                                                                                                                          | Linked Record |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| DR-01 | The betterleaks workflow SHALL be implemented as an independent reusable workflow rather than delegating to the external `aglabo/.github` reusable workflow `r1.1.2`.                             | —             |
+| DR-02 | The workflow SHALL use the local `validate-environment` action before installing or running betterleaks.                                                                                          | —             |
+| DR-03 | The workflow SHALL use the local `setup-tool` action to install betterleaks.                                                                                                                      | —             |
+| DR-04 | The betterleaks version SHALL be configurable by workflow input and SHALL provide a default value.                                                                                                | —             |
+| DR-05 | The workflow SHALL checkout the configuration repository into the `shared/` directory (default branch) and use `shared/configs/betterleaks.toml` instead of the local `configs/betterleaks.toml`. | —             |
+| DR-06 | A non-zero betterleaks scan exit code SHALL immediately fail the workflow.                                                                                                                        | —             |
+| DR-07 | The configuration repository SHALL be configurable via an input parameter with `aglabo/.github` as the default, allowing users to point to their own repository.                                  | —             |
+
+## 4. Functional Requirements
+
+### REQ-F-001: Environment Validation
+
+- EARS Type: event-driven
+
+```text
+GIVEN the betterleaks reusable workflow has started
+  WHEN the scan job begins
+THEN the workflow MUST run the local validate-environment action v0.1.1
+     before installing or running betterleaks.
+```
+
+```text
+GIVEN the local validate-environment action returns a failed validation state
+  WHEN validation fails
+THEN the workflow MUST stop before betterleaks installation and scan execution.
+```
+
+**Rationale**: Environment validation ensures the runner meets prerequisites before any tool installation or scan execution.
+
+### REQ-F-001b: Target Repository Checkout Depth
+
+- EARS Type: feature-based
+
+```text
+GIVEN the workflow checks out the target repository for scanning
+  WHERE the fetch-depth input is provided
+THEN the workflow MUST use the specified fetch-depth value when checking out the target repository.
+```
+
+```text
+GIVEN no fetch-depth input is provided
+  WHEN checking out the target repository
+THEN the workflow MUST use a default fetch-depth of 1 (latest commit only).
+```
+
+**Rationale**: Limiting fetch depth to the latest commit reduces checkout time and scan surface. Full history (fetch-depth: 0) is available when callers need to scan all commits.
+
+### REQ-F-002: Tool Installation
+
+- EARS Type: event-driven
+
+```text
+GIVEN environment validation has completed successfully
+  WHEN the workflow prepares the scan tool
+THEN the workflow MUST run the local setup-tool action to install betterleaks,
+     passing the repo input in owner/repo format and the resolved tool-version.
+```
+
+```text
+GIVEN no betterleaks version input is provided
+  WHEN installing betterleaks
+THEN the workflow MUST use the workflow-defined default betterleaks version.
+```
+
+**Rationale**: Using setup-tool centralizes tool installation logic and ensures checksum verification.
+
+### REQ-F-003: Config Checkout
+
+- EARS Type: event-driven
+
+```text
+GIVEN the workflow needs the betterleaks scan configuration
+  WHEN preparing scan inputs
+THEN the workflow MUST checkout the repository specified by the config-repo input parameter
+     into the shared/ directory and MUST use shared/configs/betterleaks.toml from that checkout.
+```
+
+```text
+GIVEN no config-repo input is provided
+  WHEN checking out the configuration repository
+THEN the workflow MUST use aglabo/.github as the default configuration repository.
+```
+
+```text
+GIVEN the local repository contains configs/betterleaks.toml
+  WHEN executing this workflow
+THEN the workflow MUST NOT use the local configs/betterleaks.toml
+     as the scan configuration.
+```
+
+**Rationale**: Making the configuration repository configurable allows users to fork or replace the shared configuration while keeping `aglabo/.github` as a sensible default.
+
+### REQ-F-004: Secret Scan Execution
+
+- EARS Type: event-driven
+
+```text
+GIVEN betterleaks has been installed and the shared configuration has been checked out
+  WHEN executing the secret scan
+THEN the workflow MUST run betterleaks against the target repository
+     using the checked-out shared/configs/betterleaks.toml configuration,
+     equivalent to: betterleaks protect --config shared/configs/betterleaks.toml.
+```
+
+**Rationale**: Scanning with a shared configuration guarantees uniform secret detection rules.
+
+### REQ-F-007: Scan Report Output
+
+- EARS Type: event-driven
+
+```text
+GIVEN betterleaks is executed
+  WHEN the scan runs
+THEN the workflow MUST output the scan result as a JSON report file at .github/report/betterleaks-report.json.
+```
+
+```text
+GIVEN the report directory does not exist
+  WHEN the workflow prepares for scanning
+THEN the workflow MUST create the .github/report/ directory before running betterleaks.
+```
+
+**Rationale**: A machine-readable report enables downstream processing and artifact retention for audit purposes.
+
+### REQ-F-008: Report Upload on Failure
+
+- EARS Type: event-driven
+
+```text
+GIVEN betterleaks exits with a non-zero exit code indicating a violation
+  WHEN the scan step fails
+THEN the workflow MUST upload the scan report as a workflow artifact named betterleaks-report.
+```
+
+```text
+GIVEN betterleaks exits with exit code 0 (no violations)
+  WHEN the scan step succeeds
+THEN the workflow MUST NOT upload any artifact.
+```
+
+**Rationale**: Uploading the report only on failure avoids artifact storage costs on clean runs while ensuring evidence is preserved when secrets are detected.
+
+### REQ-F-005: Fail-Fast on Scan Failure
+
+- EARS Type: unwanted behavior
+
+```text
+GIVEN betterleaks exits with a non-zero exit code
+  NOT DO suppress the failure with continue-on-error
+THEN the workflow MUST immediately fail the scan step and job.
+```
+
+**Rationale**: Secret findings must block unsafe changes without exception.
+
+### REQ-F-006: Workflow Triggers
+
+- EARS Type: feature-based
+
+```text
+GIVEN another workflow needs to invoke the betterleaks scan
+  WHERE the workflow_call trigger is defined
+THEN the betterleaks workflow MUST be executable as a reusable workflow.
+```
+
+```text
+GIVEN a user needs to run the betterleaks scan manually
+  WHERE the workflow_dispatch trigger is defined
+THEN the betterleaks workflow MUST support manual execution from GitHub Actions.
+```
+
+```text
+GIVEN either workflow_call or workflow_dispatch is used
+  WHEN a betterleaks version input is supplied
+THEN the workflow MUST use the supplied value for tool installation.
+```
+
+```text
+GIVEN either workflow_call or workflow_dispatch is used
+  WHEN a config-repo input is supplied
+THEN the workflow MUST use the supplied value as the configuration repository to checkout.
+```
+
+**Rationale**: Supporting both triggers and configurable inputs provides flexibility for automated and ad-hoc scanning across different configurations.
+
+## 5. Non-Functional Requirements
+
+### REQ-NF-001: Maintainability
+
+The workflow SHOULD keep tool setup, environment validation, configuration checkout, and scan execution as separate named steps.
+
+### REQ-NF-002: Security — Minimum Permissions
+
+The workflow MUST request only the minimum permissions required and MUST include `contents: read`.
+
+### REQ-NF-003: Security — No Hard-coded Tokens
+
+The workflow MUST use GitHub Actions secrets or context values for `github-token` and MUST NOT hard-code tokens.
+
+### REQ-NF-004: Reproducibility — Version Pinning
+
+The betterleaks version MUST be resolved from the explicit workflow input or default value.
+
+### REQ-NF-005: Reproducibility — Config Path
+
+The workflow MUST reference the checked-out `aglabo/.github` configuration path deterministically.
+
+### REQ-NF-006: Observability
+
+Failed step names and command context SHOULD make the failure source identifiable from the GitHub Actions log.
+
+## 6. Constraints
+
+### REQ-C-001: Runner
+
+The scan job MUST run on `ubuntu-latest`.
+
+### REQ-C-002: Permissions
+
+The workflow MUST include `contents: read` in its permissions block.
+
+### REQ-C-003: Tool Version Format
+
+The betterleaks version input SHOULD use `X.Y.Z` version format.
+
+### REQ-C-004: Minimum Compatible Versions
+
+The default betterleaks version SHALL be `1.4.1`, which is compatible with betterleaks minimum version `v1.0.0` and gitleaks minimum version `v8.25.0`.
+
+### REQ-C-005: Local Actions Only
+
+The workflow MUST use local actions from this repository rather than the external `aglabo/.github` reusable workflow `r1.1.2` for environment validation and tool installation.
+
+### REQ-C-006: Configuration Source
+
+The workflow MUST checkout the configuration repository into the `shared/` directory and use `shared/configs/betterleaks.toml` as the scan configuration. The configuration repository MUST default to `aglabo/.github` when no `config-repo` input is provided.
+
+## 7. User Stories
+
+- As a platform engineer, I want a local reusable betterleaks workflow. Because repository workflows should not depend on the external `aglabo/.github` reusable workflow `r1.1.2`.
+- As a repository maintainer, I want to call the betterleaks scan from my CI workflow. Because secret scanning should be reusable across repositories.
+- As a security engineer, I want the workflow to use the shared `aglabo/.github` betterleaks configuration by default. Because scan policy should be centralized and consistent.
+- As a user of a forked environment, I want to specify my own configuration repository. Because my organization may maintain a customized betterleaks configuration.
+- As a CI operator, I want betterleaks failures to fail the workflow immediately. Because secret findings must block unsafe changes.
+- As a developer, I want to manually run the betterleaks workflow. Because I may need to verify a branch outside normal CI execution.
+
+## 8. Acceptance Criteria
+
+```gherkin
+# AC-001: Reusable Workflow Runs Successfully
+# Requirement: REQ-F-001, REQ-F-002, REQ-F-003, REQ-F-004, REQ-F-006
+Scenario: Reusable Workflow Runs Successfully
+  Given a caller workflow invokes the betterleaks workflow through workflow_call
+  And no secrets are detected by betterleaks
+  When the workflow runs on ubuntu-latest
+  Then the workflow validates the environment
+  And installs the configured betterleaks version
+  And checks out the default aglabo/.github configuration repository
+  And runs betterleaks using shared/configs/betterleaks.toml from that checkout
+  And the workflow completes successfully
+
+# AC-002: Manual Workflow Runs Successfully
+# Requirement: REQ-F-002, REQ-F-004, REQ-F-006
+Scenario: Manual Workflow Runs Successfully
+  Given a user starts the betterleaks workflow through workflow_dispatch
+  And the user provides a valid betterleaks version input
+  And no secrets are detected by betterleaks
+  When the workflow runs
+  Then the workflow installs the provided betterleaks version
+  And runs betterleaks with the shared configuration
+  And the workflow completes successfully
+
+# AC-003: Default Betterleaks Version Is Used
+# Requirement: REQ-F-002, REQ-F-006
+Scenario: Default Betterleaks Version Is Used
+  Given the betterleaks workflow is started without a betterleaks version input
+  When the setup-tool action installs betterleaks
+  Then the workflow uses the default betterleaks version
+  And the scan runs with the shared betterleaks configuration
+
+# AC-004: Scan Failure Fails Fast
+# Requirement: REQ-F-005
+Scenario: Scan Failure Fails Fast
+  Given the betterleaks workflow is running
+  And betterleaks detects a secret
+  When betterleaks exits with a non-zero exit code
+  Then the scan step fails immediately
+  And the job fails
+  And the workflow does not suppress the failure
+
+# AC-005: Environment Validation Failure Blocks Scan
+# Requirement: REQ-F-001
+Scenario: Environment Validation Failure Blocks Scan
+  Given the betterleaks workflow has started
+  And validate-environment reports a failed validation state
+  When the validation step completes
+  Then the workflow fails before setup-tool runs
+  And betterleaks is not executed
+```
+
+## 9. Open Questions
+
+| Question                                                                                                | Type      | Impact Area                                | Owner               |
+| ------------------------------------------------------------------------------------------------------- | --------- | ------------------------------------------ | ------------------- |
+| ~~What exact default betterleaks version should the workflow use?~~                                     | Product   | Tool installation, reproducibility         | **Resolved: 1.4.1** |
+| Should the `shared` branch name be hardcoded or made configurable in a future version?                  | Technical | Configuration reproducibility, flexibility | Platform Team       |
+| Should the workflow scan the entire repository by default or support path filtering in a later version? | Product   | Scan scope                                 | Security Team       |
+
+## 10. Change History
+
+| Date       | Version | Description                                                                                              |
+| ---------- | ------- | -------------------------------------------------------------------------------------------------------- |
+| 2026-06-12 | 1.5.0   | Add fetch-depth input (REQ-F-001b), scan report output (REQ-F-007), report upload on failure (REQ-F-008) |
+| 2026-06-12 | 1.4.0   | Change config-repo checkout: path=shared/ (default branch), config=shared/configs/betterleaks.toml       |
+| 2026-06-12 | 1.3.0   | Fix default betterleaks version to `1.4.1`                                                               |
+| 2026-06-12 | 1.2.0   | Fix config-repo checkout branch to `shared` (not default branch) — superseded by 1.4.0                   |
+| 2026-06-12 | 1.1.0   | Add config-repo input parameter (user-configurable configuration repository, default: aglabo/.github)    |
+| 2026-06-12 | 1.0.0   | Initial release                                                                                          |

--- a/docs/.deckrd/reusable-workflows/betterleaks/specifications/specifications.md
+++ b/docs/.deckrd/reusable-workflows/betterleaks/specifications/specifications.md
@@ -1,0 +1,305 @@
+---
+title: "Design Specification: Betterleaks Reusable Workflow"
+based-on: requirements.md v1.1
+status: Draft
+---
+
+<!-- markdownlint-disable line-length -->
+
+## 1. Overview
+
+### 1.1 Purpose
+
+This specification defines the behavioral design for the Betterleaks reusable workflow. It describes workflow inputs, validation behavior, installation behavior, external configuration resolution, scan execution, failure semantics, and traceability to requirements.
+
+<!-- impl-note: Module path: reusable-workflows/betterleaks -->
+
+### 1.2 Scope
+
+This specification covers the reusable workflow behavior from trigger input resolution through environment validation, tool installation, configuration checkout, and secret scan execution.
+
+It defines observable workflow behavior only. Implementation-specific action wiring, exact YAML syntax, and local file layout are implementation details unless carried in `impl-note` comments.
+
+## 2. Design Principles
+
+### 2.1 Classification Philosophy
+
+The workflow SHALL be treated as a fail-fast quality gate.
+
+Each unit SHALL have a single behavioral responsibility:
+
+| Unit            | Responsibility                                                                   |
+| --------------- | -------------------------------------------------------------------------------- |
+| trigger-inputs  | Resolve caller-provided inputs and defaults                                      |
+| env-validation  | Verify the runner and workflow environment before downstream execution           |
+| tool-install    | Install the scanner tool into the executable search path                         |
+| config-checkout | Retrieve the shared scanner configuration source                                 |
+| scan-execute    | Execute the scan and fail immediately on detected violations or execution errors |
+
+### 2.2 Design Assumptions
+
+| Assumption                    | Description                                                                                                     |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Hosted runner compatibility   | The workflow runs on a Linux hosted runner compatible with the scanner and local composite actions.             |
+| Read-only repository access   | The workflow requires repository read access only.                                                              |
+| External configuration source | Scanner configuration is obtained from the configured shared repository source, not from the caller repository. |
+| Fixed checkout path           | The configuration source is always checked out into the `shared/` directory (default branch).                   |
+| Scanner failure semantics     | A non-zero scanner exit status represents a workflow failure.                                                   |
+| No published outputs          | The workflow communicates success or failure through job status only.                                           |
+
+### 2.3 External Design Summary
+
+#### Feature Decomposition
+
+| Unit            | Pre-Conditions                   | Post-Conditions                                                 | Failure Behavior                                       |
+| --------------- | -------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------ |
+| trigger-inputs  | Workflow has been invoked        | Effective scanner version and configuration source are resolved | SHALL NOT fail under normal input omission             |
+| env-validation  | Workflow has started             | Environment status is successful                                | SHALL block all downstream units on validation error   |
+| tool-install    | Environment validation succeeded | Scanner is available in the executable search path              | SHALL fail the job on installation error               |
+| config-checkout | Tool installation succeeded      | Shared scanner configuration source is available locally        | SHALL fail the job when the source cannot be retrieved |
+| scan-execute    | Configuration checkout completed | Scanner exits successfully                                      | SHALL fail immediately on non-zero scanner exit        |
+
+<!-- impl-note: Local env-validation composite action inputs: architecture=amd64, actions-type=read, require-github-hosted=false. -->
+<!-- impl-note: Local setup-tool composite action installs betterleaks/betterleaks into ${RUNNER_TEMP}/bin and appends that directory to GITHUB_PATH. -->
+<!-- impl-note: Configuration checkout implementation path: shared. Required scanner config: shared/configs/betterleaks.toml. -->
+
+#### Unit Interaction Map
+
+```text
++----------------+
+| trigger-inputs |
++-------+--------+
+        |
+        v
++----------------+
+| env-validation |
++-------+--------+
+        |
+        v
++----------------+
+|  tool-install  |
++-------+--------+
+        |
+        v
++-----------------+
+| config-checkout |
++-------+---------+
+        |
+        v
++----------------+
+|  scan-execute  |
++----------------+
+```
+
+#### Data Flow Diagram
+
+```text
+Caller Inputs
+  | betterleaks-version
+  | config-repo
+  v
++----------------+
+| trigger-inputs |
++-------+--------+
+        |
+        | effective scanner version
+        | effective configuration source
+        v
++----------------+
+| env-validation |
++-------+--------+
+        | success
+        v
++----------------+
+|  tool-install  |
++-------+--------+
+        | success
+        v
++-----------------+
+| config-checkout |
++-------+---------+
+        | success
+        v
++----------------+
+|  scan-execute  |
++----------------+
+        |
+        v
+Workflow Status: success or failed
+```
+
+### 2.4 Non-Goals
+
+| Non-Goal                                      | Reason                                                                           |
+| --------------------------------------------- | -------------------------------------------------------------------------------- |
+| Publishing workflow outputs                   | The workflow is fail-fast only and has no output contract.                       |
+| Supporting caller-local scanner configuration | The configuration source is deterministic and external to the caller repository. |
+| Supporting a configuration source ref input   | The configuration source is checked out from its default branch into `shared/`.  |
+| Requesting write permissions                  | The workflow requires read-only repository access.                               |
+| Continuing after scanner failure              | Scanner failure SHALL fail the workflow immediately.                             |
+| Delegating to an external reusable workflow   | The architecture uses local composite actions only.                              |
+
+### 2.5 Behavioral Design Decisions
+
+| ID     | Decision                                                                                    | Rationale                                                                                   | Affected Rules | Status   |
+| ------ | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | -------------- | -------- |
+| DD-001 | The workflow SHALL resolve missing scanner version input to a default stable version.       | Callers should be able to use the workflow without specifying a version.                    | R-001          | Accepted |
+| DD-002 | The workflow SHALL resolve missing configuration source input to the shared default source. | The default source provides organization-wide scanner policy.                               | R-002          | Accepted |
+| DD-003 | Environment validation SHALL run before installation and scanning.                          | Invalid runtime conditions should stop the workflow before side effects or scan work occur. | R-003, R-004   | Accepted |
+| DD-004 | Tool installation SHALL be gated by successful environment validation.                      | Installation should occur only in a validated environment.                                  | R-005, R-006   | Accepted |
+| DD-005 | Configuration checkout SHALL be gated by successful tool installation.                      | Configuration should be retrieved only when scanning can proceed.                           | R-007, R-008   | Accepted |
+| DD-006 | Scan execution SHALL be gated by completed configuration checkout.                          | The scanner requires the shared configuration source.                                       | R-009, R-010   | Accepted |
+| DD-007 | Scanner non-zero exit SHALL fail the workflow immediately.                                  | Secret detection and execution errors are blocking quality gate failures.                   | R-011          | Accepted |
+| DD-008 | Workflow permissions SHALL be limited to read-only repository content access.               | The workflow does not require mutation privileges.                                          | R-012          | Accepted |
+
+### 2.6 Related Decision Records
+
+| DR ID | Decision                                                 | Specification Impact                                                                        |
+| ----- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| DR-01 | Independent reusable workflow                            | The workflow SHALL use local composition rather than external reusable workflow delegation. |
+| DR-02 | Validate environment before install and scan             | Environment validation SHALL be the first executable gate after input resolution.           |
+| DR-03 | Use local tool installer                                 | Tool installation SHALL be performed by the local installation unit.                        |
+| DR-04 | Scanner version configurable via input with default      | The scanner version SHALL be caller-configurable and defaulted when omitted.                |
+| DR-05 | Configuration from checked-out repository source         | Scanner configuration SHALL come from the configured external source.                       |
+| DR-06 | Fail-fast on non-zero scanner exit                       | Scan failure SHALL fail the workflow immediately.                                           |
+| DR-07 | Configuration source configurable via input with default | The configuration source SHALL be caller-configurable and defaulted when omitted.           |
+
+### 2.7 DD to DR Promotion Criteria
+
+A design decision SHOULD be promoted to a decision record when any of the following are true:
+
+| Criterion              | Promotion Trigger                                                                               |
+| ---------------------- | ----------------------------------------------------------------------------------------------- |
+| Cross-module impact    | The decision affects other reusable workflows or shared composite actions.                      |
+| Public contract impact | The decision changes workflow inputs, permissions, triggers, or failure semantics.              |
+| Migration cost         | Reversing the decision would require caller changes.                                            |
+| Security posture       | The decision changes token usage, permissions, configuration source trust, or failure handling. |
+| Operational policy     | The decision encodes organization-wide CI policy.                                               |
+
+## 3. Behavioral Specification
+
+### 3.1 Input Domain
+
+| Input               | Required | Default        | Constraints                                                                                                    | Behavior                                     |
+| ------------------- | -------- | -------------- | -------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| betterleaks-version | No       | `1.4.1`        | MUST be compatible with supported scanner releases; SHALL use semantic version format when explicitly supplied | Determines the scanner version to install    |
+| config-repo         | No       | aglabo/.github | MUST identify an accessible repository source                                                                  | Determines the external configuration source |
+| fetch-depth         | No       | `1`            | MUST be a non-negative integer; `0` means full history                                                         | Controls git fetch depth for target checkout |
+
+<!-- impl-note: betterleaks-version maps to setup-tool tool-version and must satisfy X.Y.Z format. -->
+<!-- impl-note: config-repo default is aglabo/.github. The configuration source is checked out into shared/ (default branch, no ref specified). -->
+<!-- impl-note: fetch-depth maps to actions/checkout with.fetch-depth. Default 1 fetches latest commit only. -->
+
+### 3.2 Output Semantics
+
+The workflow SHALL publish no reusable workflow outputs.
+
+The observable result SHALL be one of:
+
+| Result  | Meaning                                                                                         |
+| ------- | ----------------------------------------------------------------------------------------------- |
+| Success | All units completed successfully and the scanner exited with status `0`.                        |
+| Failure | Environment validation, tool installation, configuration checkout, or scanner execution failed. |
+
+On failure, the workflow SHALL produce a JSON report artifact named `betterleaks-report` at `.github/report/betterleaks-report.json`.
+
+### 3.3 Step Execution Semantics
+
+The workflow SHALL execute units in this order:
+
+```text
+trigger-inputs -> env-validation -> target-checkout -> tool-install -> config-checkout -> prepare-report -> scan-execute -> upload-report
+```
+
+Each executable unit after input resolution SHALL be conditioned on the previous unit succeeding.
+
+The scanner execution unit SHALL fail fast. It MUST NOT ignore a non-zero scanner exit status and MUST NOT continue on scan failure.
+
+<!-- impl-note: Step gating pattern: if: steps.<id>.outcome == 'success'. -->
+<!-- impl-note: Scanner command: betterleaks protect --config shared/configs/betterleaks.toml --report-path=.github/report/betterleaks-report.json --exit-code=1 -->
+<!-- impl-note: upload-report step uses: actions/upload-artifact, if: failure() && steps.scan-execute.outputs.status != '0', name: betterleaks-report, path: .github/report/betterleaks-report.json -->
+<!-- impl-note: target-checkout uses fetch-depth: ${{ inputs.fetch-depth }} and persist-credentials: false -->
+
+## 4. Decision Rules
+
+| Rule ID | Step            | Condition                                                | Outcome                                                                                                               |
+| ------- | --------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| R-001   | trigger-inputs  | `betterleaks-version` is omitted                         | The workflow SHALL resolve the default scanner version `1.4.1`.                                                       |
+| R-002   | trigger-inputs  | `config-repo` is omitted                                 | The workflow SHALL resolve the default shared configuration source (`aglabo/.github`).                                |
+| R-003   | env-validation  | Workflow execution has started                           | The workflow SHALL validate the runner and action environment before installation or scanning.                        |
+| R-004   | env-validation  | Environment validation reports an error status           | The workflow SHALL block tool installation, configuration checkout, and scan execution.                               |
+| R-005   | tool-install    | Environment validation succeeded                         | The workflow SHALL install the requested scanner version into the executable search path.                             |
+| R-006   | tool-install    | Tool installation fails                                  | The workflow SHALL fail the job and SHALL NOT run configuration checkout or scan execution.                           |
+| R-007   | config-checkout | Tool installation succeeded                              | The workflow SHALL checkout the configured shared configuration source into the `shared/` directory (default branch). |
+| R-008   | config-checkout | The configured source is inaccessible                    | The workflow SHALL fail the job and SHALL NOT run scan execution.                                                     |
+| R-009   | scan-execute    | Configuration checkout completed                         | The workflow SHALL execute the scanner using the shared scanner configuration.                                        |
+| R-010   | scan-execute    | Shared scanner configuration is absent or unusable       | The scanner execution SHALL fail and the workflow SHALL fail immediately.                                             |
+| R-011   | scan-execute    | Scanner exits with a non-zero status                     | The workflow MUST fail immediately and MUST NOT continue on error.                                                    |
+| R-012   | workflow        | Workflow permissions are evaluated                       | The workflow SHALL request read-only repository contents permission.                                                  |
+| R-013   | workflow        | Workflow is invoked by reusable call or manual dispatch  | The workflow SHALL expose the same behavioral inputs for both invocation modes.                                       |
+| R-014   | workflow        | A downstream unit is evaluated after an upstream failure | The downstream unit SHALL be skipped unless explicitly covered by fail-fast scan behavior.                            |
+| R-015   | trigger-inputs  | `fetch-depth` is omitted                                 | The workflow SHALL resolve the default fetch depth `1`.                                                               |
+| R-016   | target-checkout | fetch-depth is resolved                                  | The workflow SHALL pass the resolved fetch-depth to the target repository checkout.                                   |
+| R-017   | prepare-report  | scan-execute is about to run                             | The workflow SHALL create the `.github/report/` directory before executing the scanner.                               |
+| R-018   | scan-execute    | Scanner runs                                             | The workflow SHALL write scan results to `.github/report/betterleaks-report.json`.                                    |
+| R-019   | scan-execute    | Scanner exits with non-zero status                       | The workflow SHALL expose the scanner exit code as a step output named `status`.                                      |
+| R-020   | upload-report   | Scan step exits with non-zero status                     | The workflow SHALL upload `.github/report/betterleaks-report.json` as artifact `betterleaks-report` on failure only.  |
+| R-021   | upload-report   | Scan step exits with status `0`                          | The workflow MUST NOT upload any artifact.                                                                            |
+
+## 5. Edge Cases
+
+| Input                                      | Behavior                                                            | REQ                   | Rationale                                                             |
+| ------------------------------------------ | ------------------------------------------------------------------- | --------------------- | --------------------------------------------------------------------- |
+| `betterleaks-version` omitted              | The workflow SHALL use the default scanner version `1.4.1`.         | REQ-F-002, REQ-NF-004 | Callers should not need to know the current approved version.         |
+| `config-repo` omitted                      | The workflow SHALL use the default shared configuration source.     | REQ-F-003, REQ-C-006  | Organization-wide policy should apply by default.                     |
+| Explicit scanner version is not acceptable | Tool installation SHALL fail the job.                               | REQ-C-003, REQ-C-004  | Invalid or unsupported versions cannot produce reliable scan results. |
+| Configuration source is inaccessible       | Configuration checkout SHALL fail the job.                          | REQ-F-003, REQ-F-005  | A scan without policy configuration is not valid.                     |
+| Shared scanner configuration is absent     | Scanner execution SHALL fail fast.                                  | REQ-F-004, REQ-F-005  | Missing configuration is a blocking scan setup error.                 |
+| Scanner detects a violation                | Scanner execution SHALL fail fast.                                  | REQ-F-005             | Secret findings are blocking quality gate failures.                   |
+| Environment validation reports an error    | All downstream units SHALL be blocked.                              | REQ-F-001             | Invalid execution environments should stop before install or scan.    |
+| Caller expects workflow outputs            | No outputs SHALL be produced.                                       | Function Decisions    | The workflow communicates only by job status.                         |
+| `fetch-depth` omitted                      | The workflow SHALL use fetch-depth `1`.                             | REQ-F-001b            | Default fetches only the latest commit for efficiency.                |
+| `fetch-depth: 0` supplied                  | The workflow SHALL fetch full git history for the target repo.      | REQ-F-001b            | Full history scanning when required by the caller.                    |
+| Scanner detects violation (report upload)  | The scan report SHALL be uploaded as artifact `betterleaks-report`. | REQ-F-008             | Preserves evidence for audit when secrets are found.                  |
+| Scanner succeeds (no violation)            | No artifact SHALL be uploaded.                                      | REQ-F-008             | Avoids unnecessary artifact storage on clean runs.                    |
+
+## 6. Requirements Traceability
+
+| REQ ID     | Rule IDs                          | Notes                                                                                    |
+| ---------- | --------------------------------- | ---------------------------------------------------------------------------------------- |
+| REQ-F-001  | R-003, R-004, R-014               | Environment validation runs before install and scan and blocks downstream failure paths. |
+| REQ-F-002  | R-001, R-005, R-006               | Scanner installation uses the resolved version and fails the job on installation error.  |
+| REQ-F-003  | R-002, R-007, R-008, R-010        | Configuration comes from the configured shared source and is required for scanning.      |
+| REQ-F-004  | R-009, R-010, R-011               | Scanner execution uses the shared configuration and fails on execution error.            |
+| REQ-F-005  | R-010, R-011                      | Scan setup errors and non-zero scanner exits are fail-fast failures.                     |
+| REQ-F-006  | R-013                             | Both reusable and manual invocation expose the same behavioral inputs.                   |
+| REQ-NF-001 | R-003, R-005, R-007, R-009        | Each unit is represented by a separate named workflow step.                              |
+| REQ-NF-002 | R-012                             | Permissions are limited to read-only repository contents access.                         |
+| REQ-NF-003 | R-012                             | No hard-coded tokens are required by the behavioral contract.                            |
+| REQ-NF-004 | R-001, R-005                      | Scanner version comes from input resolution.                                             |
+| REQ-NF-005 | R-007, R-009, R-010               | Configuration location and source are deterministic.                                     |
+| REQ-NF-006 | R-004, R-006, R-008, R-010, R-011 | Failure occurs in the named unit responsible for the failed behavior.                    |
+| REQ-C-001  | R-003                             | Runner compatibility is validated before downstream execution.                           |
+| REQ-C-002  | R-012                             | Read-only contents permission is required.                                               |
+| REQ-C-003  | R-005, R-006                      | Explicit scanner versions must satisfy installer constraints.                            |
+| REQ-C-004  | R-001, R-005                      | Default version must remain compatible with supported scanner releases.                  |
+| REQ-C-005  | R-003, R-005                      | Local composite actions provide validation and installation behavior.                    |
+| REQ-C-006  | R-002, R-007, R-009               | Shared configuration source and default are part of the workflow contract.               |
+| REQ-F-001b | R-015, R-016                      | fetch-depth input controls target checkout depth; default 1.                             |
+| REQ-F-007  | R-017, R-018                      | Report directory is created before scan; report written to .github/report/.              |
+| REQ-F-008  | R-019, R-020, R-021               | Report uploaded as artifact on failure only; exit code exposed as step output.           |
+
+## 7. Open Questions
+
+| #     | Question                                                             | Source             | Impact                |
+| ----- | -------------------------------------------------------------------- | ------------------ | --------------------- |
+| ~~1~~ | ~~What exact scanner version is the default latest stable version?~~ | Function Decisions | **Resolved: `1.4.1`** |
+
+## 8. Change History
+
+| Date       | Version | Change                                                                                                  |
+| ---------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| 2026-06-12 | 1.3.0   | Add fetch-depth input (R-015/R-016), report output (R-017/R-018), upload on failure (R-019/R-020/R-021) |
+| 2026-06-12 | 1.2.0   | Set default betterleaks version to `1.4.1`                                                              |
+| 2026-06-12 | 1.1.0   | Fix config-repo checkout branch to `shared` (not default branch)                                        |
+| 2026-06-12 | 1.0.0   | Initial specification                                                                                   |

--- a/docs/.deckrd/reusable-workflows/betterleaks/tasks/tasks.md
+++ b/docs/.deckrd/reusable-workflows/betterleaks/tasks/tasks.md
@@ -1,0 +1,324 @@
+---
+title: "Implementation Tasks"
+module: "reusable-workflows/betterleaks"
+status: Active
+created: "2026-06-12 00:00:00"
+source: specifications.md
+---
+
+<!-- markdownlint-disable no-duplicate-heading line-length -->
+
+> This document contains implementation tasks derived from specifications.
+> Each task corresponds to a single unit test case (it() block).
+> Test method: static YAML analysis via `actionlint` (CI) and `yq` attribute inspection (local developer verification only — `yq` is NOT used inside the reusable workflow itself).
+> The `yq:` lines in each task are implementation hints for the developer writing the test, not workflow steps.
+
+---
+
+## Task Summary
+
+| Test Target                  | Scenario Groups            | Case Count |
+| ---------------------------- | -------------------------- | ---------: |
+| T-01: Workflow structure     | Normal / Error / Edge case |          9 |
+| T-02: Step chain             | Normal / Error / Edge case |          9 |
+| T-03: Failure propagation    | Error / Edge case          |          6 |
+| T-04: YAML static validation | Normal                     |          4 |
+| T-05: Fetch depth and report | Normal / Error / Edge case |          9 |
+| **Total**                    | 15 scenario groups         |     **37** |
+
+---
+
+## T-01: Workflow Structure
+
+### [正常] Normal Cases
+
+#### T-01-01: Inputs and triggers are correctly defined
+
+- [x] **T-01-01-01**: Verify `betterleaks-version` input for `workflow_call` has correct default and is optional
+  - Target: `on.workflow_call.inputs.betterleaks-version`
+  - Scenario: Given the reusable workflow is defined, When `workflow_call` inputs are inspected
+  - Expected: Then `required: false` and `default: "1.4.1"`
+  - `yq`: `.on.workflow_call.inputs."betterleaks-version".required == false and .on.workflow_call.inputs."betterleaks-version".default == "1.4.1"`
+
+- [x] **T-01-01-02**: Verify `config-repo` input for `workflow_call` defaults to `aglabo/.github`
+  - Target: `on.workflow_call.inputs.config-repo`
+  - Scenario: Given the reusable workflow is defined, When `workflow_call` inputs are inspected
+  - Expected: Then `required: false` and `default: aglabo/.github`
+  - `yq`: `.on.workflow_call.inputs."config-repo".required == false and .on.workflow_call.inputs."config-repo".default == "aglabo/.github"`
+
+- [x] **T-01-01-02b**: Verify `fetch-depth` input for `workflow_call` defaults to `50` and is optional
+  - Target: `on.workflow_call.inputs.fetch-depth`
+  - Scenario: Given the reusable workflow is defined, When `workflow_call` inputs are inspected
+  - Expected: Then `required: false`, `default: 50`, `type: number`
+  - `yq`: `.on.workflow_call.inputs."fetch-depth".required == false and .on.workflow_call.inputs."fetch-depth".default == 50`
+
+- [x] **T-01-01-04**: Verify `betterleaks-version` and `config-repo` inputs declare `type: string` for `workflow_call`
+  - Target: `on.workflow_call.inputs`
+  - Scenario: Given inputs are defined for `workflow_call`
+  - Expected: Then `betterleaks-version` and `config-repo` have `type: string` under `workflow_call`
+  - `yq`: `.on.workflow_call.inputs."betterleaks-version".type == "string" and .on.workflow_call.inputs."config-repo".type == "string"`
+
+- [x] **T-01-01-05**: Verify top-level permissions grant only `contents: read`
+  - Target: `permissions.contents`
+  - Scenario: Given workflow permissions are evaluated, When the top-level permissions block is inspected
+  - Expected: Then `permissions.contents` is `read` and no other permissions keys exist at top level
+  - `yq`: `.permissions == {"contents": "read"}`
+
+- [x] **T-01-01-06**: Verify job-level permissions grant only `contents: read`
+  - Target: `jobs.*.permissions.contents`
+  - Scenario: Given job permissions are evaluated
+  - Expected: Then the single job declares `permissions.contents: read` with no additional keys
+  - `yq`: `[.jobs[].permissions] | all(. == {"contents": "read"})`
+
+### [異常] Error Cases
+
+#### T-01-02: Workflow does not expose outputs
+
+- [x] **T-01-02-01**: Verify no `workflow_call` outputs are declared
+  - Target: `on.workflow_call.outputs`
+  - Scenario: Given a caller might expect outputs
+  - Expected: Then `on.workflow_call.outputs` is absent or empty
+  - `yq`: `(.on.workflow_call.outputs // {}) == {}`
+
+- [x] **T-01-02-02**: Verify no job-level outputs are declared
+  - Target: `jobs.*.outputs`
+  - Scenario: Given jobs might declare outputs
+  - Expected: Then no job has an `outputs` block
+  - `yq`: `[.jobs[].outputs // empty] | length == 0`
+
+### [エッジケース] Edge Cases
+
+#### T-01-03: Input defaults are explicitly declared
+
+- [x] **T-01-03-01**: Verify `betterleaks-version` and `config-repo` have non-empty defaults under both triggers
+  - Target: `on.workflow_call.inputs`, `on.workflow_dispatch.inputs`
+  - Scenario: Given no value is supplied by a caller or manual dispatcher
+  - Expected: Then `betterleaks-version` default is `"1.4.1"` and `config-repo` default is `"aglabo/.github"` under both `workflow_call` and `workflow_dispatch`
+  - `yq`: `.on.workflow_call.inputs."betterleaks-version".default == "1.4.1" and .on.workflow_dispatch.inputs."betterleaks-version".default == "1.4.1"`
+
+---
+
+## T-02: Step Chain
+
+### [正常] Normal Cases
+
+#### T-02-01: Each step exists with the correct ID, action reference, and gate condition
+
+- [x] **T-02-01-01**: Verify `target-checkout` runs first with no gate condition
+  - Target: `steps` (index 0)
+  - Scenario: Given the workflow starts, When the first step is evaluated
+  - Expected: Then the first step uses `actions/checkout`, has no `if` condition, has no `with.repository` and no `with.path`
+  - `yq`: `(.jobs[].steps[0].uses | test("actions/checkout")) and (.jobs[].steps[0].if // null) == null`
+
+- [x] **T-02-01-01b**: Verify `target-checkout` passes `fetch-depth` and `persist-credentials: false`
+  - Target: `steps` (index 0) `.with`
+  - Scenario: Given the workflow starts, When the first step is inspected
+  - Expected: Then `with.fetch-depth: ${{ inputs.fetch-depth }}` and `with.persist-credentials: false`
+  - `yq`: `.jobs[].steps[0].with."fetch-depth" == "${{ inputs.fetch-depth }}" and .jobs[].steps[0].with."persist-credentials" == false`
+
+- [x] **T-02-01-02**: Verify `env-validation` step runs second with no gate condition
+  - Target: `steps.env-validation`
+  - Scenario: Given `target-checkout` completed, When the second step is evaluated
+  - Expected: Then step with `id: env-validation` uses `.github/actions/validate-environment`, sets `with.actions-type: read`, has no `if` condition, and appears at index 1 in the step list
+  - `yq`: `.jobs[].steps[1].id == "env-validation"` and `(.jobs[].steps[1].if // null) == null`
+
+- [x] **T-02-01-03**: Verify `tool-install` uses local `setup-tool` action with correct inputs and gate
+  - Target: `steps.tool-install`
+  - Scenario: Given `env-validation` completed
+  - Expected: Then step `tool-install` uses `.github/actions/setup-tool`, sets `with.repo: betterleaks/betterleaks`, `with.tool-version: ${{ inputs.betterleaks-version }}`, and has `if: steps.env-validation.outcome == 'success'`
+  - `yq`: `(.jobs[].steps[] | select(.id=="tool-install")).with.repo == "betterleaks/betterleaks" and (.jobs[].steps[] | select(.id=="tool-install")).if == "steps.env-validation.outcome == 'success'"`
+
+- [x] **T-02-01-04**: Verify `config-checkout` checks out `config-repo` (default branch) into `shared/`
+  - Target: `steps.config-checkout`
+  - Scenario: Given `tool-install` completed
+  - Expected: Then step `config-checkout` uses `actions/checkout`, sets `with.repository: ${{ inputs.config-repo }}`, `with.path: shared`, does NOT set `with.ref`, and has `if: steps.tool-install.outcome == 'success'`
+  - `yq`: `(.jobs[].steps[] | select(.id=="config-checkout")).with.path == "shared" and (.jobs[].steps[] | select(.id=="config-checkout")).with.repository == "${{ inputs.config-repo }}" and ((.jobs[].steps[] | select(.id=="config-checkout")).with.ref // null) == null`
+
+- [x] **T-02-01-05**: Verify `scan-execute` runs the correct betterleaks command and is gated on `prepare-report`
+  - Target: `steps.scan-execute`
+  - Scenario: Given `prepare-report` completed
+  - Expected: Then step `scan-execute` has `if: steps.prepare-report.outcome == 'success'` and its `run` field contains `betterleaks git . --config shared/configs/betterleaks.toml`
+  - `yq`: `(.jobs[].steps[] | select(.id=="scan-execute")).run | test("betterleaks git \\. --config shared/configs/betterleaks.toml")`
+
+- [x] **T-02-01-06**: Verify step execution order is target-checkout → env-validation → tool-install → config-checkout → prepare-report → scan-execute
+  - Target: `jobs.*.steps[*]`
+  - Scenario: Given all steps are defined
+  - Expected: Then the steps appear in the declared order: checkout first, then env-validation, then tool-install, config-checkout, prepare-report, scan-execute
+  - `yq`: `[.jobs[].steps[].id] | (index("env-validation") < index("tool-install")) and (index("tool-install") < index("config-checkout")) and (index("config-checkout") < index("scan-execute"))`
+
+### [異常] Error Cases
+
+#### T-02-02: Scan step does not suppress failures
+
+- [x] **T-02-02-01**: Verify `scan-execute` has no `continue-on-error: true`
+  - Target: `steps.scan-execute.continue-on-error`
+  - Scenario: Given the scanner exits with a non-zero code
+  - Expected: Then `continue-on-error` is absent or `false` in `scan-execute`
+  - `yq`: `((.jobs[].steps[] | select(.id=="scan-execute"))."continue-on-error" // false) == false`
+
+### [エッジケース] Edge Cases
+
+#### T-02-03: If-conditions use only immediate-upstream outcome gates
+
+- [x] **T-02-03-01**: Verify each downstream step gates only on the immediate preceding step's outcome
+  - Target: `steps.*.if`
+  - Scenario: Given any upstream unit fails
+  - Expected: Then `tool-install`, `config-checkout`, `prepare-report`, `scan-execute` each have exactly one `if` expression referencing only the preceding step outcome, with no `always()`, `failure()`, `cancelled()`, or `||` logic
+  - `yq`: `(.jobs[].steps[] | select(.id=="tool-install")).if == "steps.env-validation.outcome == 'success'"` (repeat for each step); none contain `always(`, `failure(`, `cancelled(`
+
+- [x] **T-02-03-02**: Verify no operational step has `continue-on-error: true`
+  - Target: `steps.tool-install`, `steps.config-checkout`, `steps.prepare-report`, `steps.scan-execute`
+  - Scenario: Given any step could be marked to continue on error
+  - Expected: Then none of the operational steps declare `continue-on-error: true`
+  - `yq`: `[.jobs[].steps[] | select(.id == "tool-install" or .id == "config-checkout" or .id == "prepare-report" or .id == "scan-execute") | select(."continue-on-error" == true)] | length == 0`
+
+---
+
+## T-03: Failure Propagation
+
+### [異常] Error Cases
+
+#### T-03-01: Upstream failures block all downstream steps via chained gates
+
+- [x] **T-03-01-01**: Verify all downstream `if` expressions form a complete failure-propagation chain
+  - Target: `steps.tool-install.if`, `steps.config-checkout.if`, `steps.prepare-report.if`, `steps.scan-execute.if`
+  - Scenario: Given any upstream step fails, When each downstream step is evaluated
+  - Expected: Then each downstream step's `if` references only the immediately preceding step's outcome, so failure cascades without any `always()` or `continue-on-error` bypass
+  - `yq`: all `if` values match their respective predecessor patterns (exact string match)
+
+- [x] **T-03-01-02**: Verify `config-checkout` has no `continue-on-error` so an inaccessible config-repo fails the job
+  - Target: `steps.config-checkout.continue-on-error`
+  - Scenario: Given `config-repo` is inaccessible
+  - Expected: Then `continue-on-error` is absent or `false` in `config-checkout`
+  - `yq`: `((.jobs[].steps[] | select(.id=="config-checkout"))."continue-on-error" // false) == false`
+
+- [x] **T-03-01-03**: Verify scan command hardcodes the config path so absent config fails fast
+  - Target: `steps.scan-execute.run`
+  - Scenario: Given `shared/configs/betterleaks.toml` is absent
+  - Expected: Then the run command references the exact config path without fallback, causing betterleaks to fail when the file is missing
+  - `yq`: `(.jobs[].steps[] | select(.id=="scan-execute")).run | test("--config shared/configs/betterleaks\\.toml")`
+
+### [エッジケース] Edge Cases
+
+#### T-03-02: Edge inputs and output suppression
+
+- [x] **T-03-02-01**: Verify `betterleaks-version` default is non-empty (stable version is declared)
+  - Target: `on.workflow_call.inputs.betterleaks-version.default`
+  - Scenario: Given `betterleaks-version` is omitted by the caller
+  - Expected: Then `default == "1.4.1"`
+  - `yq`: `.on.workflow_call.inputs."betterleaks-version".default == "1.4.1"`
+
+- [x] **T-03-02-02**: Verify `config-repo` default is exactly `aglabo/.github`
+  - Target: `on.workflow_call.inputs.config-repo.default`
+  - Scenario: Given `config-repo` is omitted by the caller
+  - Expected: Then `default == "aglabo/.github"`
+  - `yq`: `.on.workflow_call.inputs."config-repo".default == "aglabo/.github"`
+
+- [x] **T-03-02-03**: Verify no outputs exist at workflow or job level (fail-fast only, no status outputs)
+  - Target: `on.workflow_call.outputs`, `jobs.*.outputs`
+  - Scenario: Given a caller expects output values from the workflow
+  - Expected: Then neither the workflow nor any job declares outputs
+  - `yq`: `(.on.workflow_call.outputs // {}) == {} and ([.jobs[].outputs // empty] | length == 0)`
+
+---
+
+## T-04: YAML Static Validation
+
+### [正常] Normal Cases
+
+#### T-04-01: actionlint and structural invariants
+
+- [x] **T-04-01-01**: `actionlint` passes with no errors
+  - Target: `.github/workflows/ci-scan-betterleaks.yml`
+  - Scenario: Given the workflow YAML is created
+  - Expected: Then `actionlint .github/workflows/ci-scan-betterleaks.yml` exits 0 with no error output
+
+- [x] **T-04-01-02**: Verify the workflow has exactly one job containing all required step IDs
+  - Target: `jobs`, `jobs.*.steps[*].id`
+  - Scenario: Given the workflow is defined
+  - Expected: Then `.jobs | length == 1` and the single job's steps include all of: `env-validation`, `tool-install`, `config-checkout`, `prepare-report`, `scan-execute`, `upload-report`
+  - `yq`: `[.jobs[].steps[].id] | contains(["env-validation","tool-install","config-checkout","prepare-report","scan-execute","upload-report"])`
+
+- [x] **T-04-01-03**: Verify all step IDs are unique
+  - Target: `jobs.*.steps[*].id`
+  - Scenario: Given all steps are declared
+  - Expected: Then the list of step IDs has no duplicates
+  - `yq`: `[.jobs[].steps[].id] | (unique | length) == length`
+
+- [x] **T-04-01-04**: Verify the job runs on `ubuntu-slim`
+  - Target: `jobs.*.runs-on`
+  - Scenario: Given the job runner is configured
+  - Expected: Then `runs-on: ubuntu-slim` (project-configured self-hosted runner label per configs/actionlint.yaml)
+  - `yq`: `.jobs | to_entries | .[0].value."runs-on" == "ubuntu-slim"`
+
+---
+
+## T-05: Fetch Depth and Report
+
+### [正常] Normal Cases
+
+#### T-05-01: fetch-depth input and target-checkout configuration
+
+- [x] **T-05-01-01**: Verify `fetch-depth` input is declared with default `50` for `workflow_call`
+  - Target: `on.workflow_call.inputs.fetch-depth`
+  - Scenario: Given the workflow is defined, When `workflow_call` inputs are inspected
+  - Expected: Then `fetch-depth` exists with `required: false`, `default: 50`, `type: number`
+  - `yq`: `.on.workflow_call.inputs."fetch-depth".default == 50 and .on.workflow_call.inputs."fetch-depth".required == false`
+
+- [x] **T-05-01-02**: Verify `target-checkout` passes `fetch-depth: ${{ inputs.fetch-depth }}`
+  - Target: `steps.target-checkout.with.fetch-depth`
+  - Scenario: Given the workflow runs with a fetch-depth input
+  - Expected: Then `with.fetch-depth` equals `${{ inputs.fetch-depth }}`
+  - `yq`: `(.jobs[].steps[] | select(.id=="target-checkout")).with."fetch-depth" == "${{ inputs.fetch-depth }}"`
+
+- [x] **T-05-01-03**: Verify `target-checkout` sets `persist-credentials: false`
+  - Target: `steps.target-checkout.with.persist-credentials`
+  - Scenario: Given the target repository is checked out
+  - Expected: Then `with.persist-credentials: false`
+  - `yq`: `(.jobs[].steps[] | select(.id=="target-checkout")).with."persist-credentials" == false`
+
+#### T-05-02: Report preparation and scan output
+
+- [x] **T-05-02-01**: Verify `prepare-report` step creates `.github/report/` directory
+  - Target: `steps.prepare-report`
+  - Scenario: Given `config-checkout` completed, When the report directory step runs
+  - Expected: Then step with `id: prepare-report` runs `mkdir -p .github/report` and is gated on `steps.config-checkout.outcome == 'success'`
+  - `yq`: `(.jobs[].steps[] | select(.id=="prepare-report")).run | test("mkdir -p .github/report")`
+
+- [x] **T-05-02-02**: Verify `scan-execute` writes report to `.github/report/betterleaks-report.json`
+  - Target: `steps.scan-execute.run`
+  - Scenario: Given `prepare-report` completed, When scan runs
+  - Expected: Then the run command includes `--report-path=.github/report/betterleaks-report.json`
+  - `yq`: `(.jobs[].steps[] | select(.id=="scan-execute")).run | test("--report-path=\\.github/report/betterleaks-report\\.json")`
+
+- [x] **T-05-02-03**: Verify `scan-execute` exposes exit code as step output `status`
+  - Target: `steps.scan-execute.run`
+  - Scenario: Given the scanner runs, When the step completes
+  - Expected: Then the run script writes `status=<exit-code>` to `$GITHUB_OUTPUT`
+  - `yq`: `(.jobs[].steps[] | select(.id=="scan-execute")).run | test("GITHUB_OUTPUT")`
+
+### [異常] Error Cases
+
+#### T-05-03: Report upload on failure
+
+- [x] **T-05-03-01**: Verify `upload-report` step exists and uploads on failure only
+  - Target: `steps.upload-report`
+  - Scenario: Given the scanner exits with a non-zero code
+  - Expected: Then step with `id: upload-report` exists with `if: failure() && steps.scan-execute.outputs.status != '0'`
+  - `yq`: `(.jobs[].steps[] | select(.id=="upload-report")).if | test("failure\\(\\)")`
+
+- [x] **T-05-03-02**: Verify `upload-report` uses `actions/upload-artifact` with artifact name `betterleaks-report`
+  - Target: `steps.upload-report.with`
+  - Scenario: Given a scan violation is detected
+  - Expected: Then `with.name: betterleaks-report` and `with.path: .github/report/betterleaks-report.json`
+  - `yq`: `(.jobs[].steps[] | select(.id=="upload-report")).with.name == "betterleaks-report" and (.jobs[].steps[] | select(.id=="upload-report")).with.path == ".github/report/betterleaks-report.json"`
+
+### [エッジケース] Edge Cases
+
+#### T-05-04: fetch-depth edge values
+
+- [x] **T-05-04-01**: Verify `fetch-depth` default resolves to `50` when omitted
+  - Target: `on.workflow_call.inputs.fetch-depth.default`
+  - Scenario: Given `fetch-depth` is omitted by the caller
+  - Expected: Then `default == 50` (not 0, not null)
+  - `yq`: `.on.workflow_call.inputs."fetch-depth".default == 50`

--- a/website/package.json
+++ b/website/package.json
@@ -18,10 +18,10 @@
   "dependencies": {
     "@docusaurus/core": "3.10.1",
     "@docusaurus/faster": "^3.10.1",
-
     "@docusaurus/preset-classic": "3.10.1",
     "@mdx-js/react": "^3.1.1",
     "clsx": "^2.1.1",
+    "joi": "^18.2.1",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      joi:
+        specifier: ^18.2.1
+        version: 18.2.1
       prism-react-renderer:
         specifier: ^2.4.1
         version: 2.4.1(react@19.2.7)
@@ -1244,11 +1247,31 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@hapi/address@5.1.1':
+    resolution: {integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==}
+    engines: {node: '>=14.0.0'}
+
+  '@hapi/formula@3.0.2':
+    resolution: {integrity: sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==}
+
+  '@hapi/hoek@11.0.7':
+    resolution: {integrity: sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==}
+
   '@hapi/hoek@9.3.0':
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
 
+  '@hapi/pinpoint@2.0.1':
+    resolution: {integrity: sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==}
+
+  '@hapi/tlds@1.1.7':
+    resolution: {integrity: sha512-MgNjRwy9Ti92yVAixLmDc8dd1bJIKwO9qlWCfFQRwRmUEDPQHYn4G6hwPFvFGUTzAa0FsS+inMjLin7GnyBRhA==}
+    engines: {node: '>=14.0.0'}
+
   '@hapi/topo@5.1.0':
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
+
+  '@hapi/topo@6.0.2':
+    resolution: {integrity: sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==}
 
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
@@ -1594,6 +1617,9 @@ packages:
 
   '@slorber/remark-comment@1.0.0':
     resolution: {integrity: sha512-RCE24n7jsOj1M0UPvIQCHTe7fI0sFL4S2nwKVWwHyVr/wI/H8GosgsJGyhnsZoGFnD/P2hLf1mSbrrgSLN93NA==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
     resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
@@ -3462,6 +3488,10 @@ packages:
 
   joi@17.13.3:
     resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
+
+  joi@18.2.1:
+    resolution: {integrity: sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==}
+    engines: {node: '>= 20'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -7768,11 +7798,27 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@hapi/address@5.1.1':
+    dependencies:
+      '@hapi/hoek': 11.0.7
+
+  '@hapi/formula@3.0.2': {}
+
+  '@hapi/hoek@11.0.7': {}
+
   '@hapi/hoek@9.3.0': {}
+
+  '@hapi/pinpoint@2.0.1': {}
+
+  '@hapi/tlds@1.1.7': {}
 
   '@hapi/topo@5.1.0':
     dependencies:
       '@hapi/hoek': 9.3.0
+
+  '@hapi/topo@6.0.2':
+    dependencies:
+      '@hapi/hoek': 11.0.7
 
   '@jest/schemas@29.6.3':
     dependencies:
@@ -8212,6 +8258,8 @@ snapshots:
       micromark-factory-space: 1.1.0
       micromark-util-character: 1.2.0
       micromark-util-symbol: 1.1.0
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.7)':
     dependencies:
@@ -10203,6 +10251,16 @@ snapshots:
       '@sideway/address': 4.1.5
       '@sideway/formula': 3.0.1
       '@sideway/pinpoint': 2.0.0
+
+  joi@18.2.1:
+    dependencies:
+      '@hapi/address': 5.1.1
+      '@hapi/formula': 3.0.2
+      '@hapi/hoek': 11.0.7
+      '@hapi/pinpoint': 2.0.1
+      '@hapi/tlds': 1.1.7
+      '@hapi/topo': 6.0.2
+      '@standard-schema/spec': 1.1.0
 
   js-tokens@4.0.0: {}
 


### PR DESCRIPTION
# ci(workflows/scan-betterleaks): add reusable betterleaks secret scanning workflow

## Overview

**Summary**
Adds an independent reusable workflow for betterleaks secret scanning without depending on the external `aglabo/.github` reusable workflow `r1.1.2`.

**Background / Motivation**
Resolves issue #71. The repository needs its own betterleaks workflow to avoid coupling to an external reusable workflow. This change makes the scan version and configuration repository explicit and locally controlled.

## Changes

### Core Changes

- `.github/workflows/ci-scan-betterleaks.yml` — new reusable workflow; supports `workflow_call` and `workflow_dispatch`, with inputs for `betterleaks-version` (default: `1.4.1`), `config-repo` (default: `aglabo/.github`), and `fetch-depth` (default: `1`)

### Test Updates

N/A — no ShellSpec tests for GitHub Actions workflows.

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] Configuration
- [x] CI/CD
- [ ] Other

## Related Issues

Related #71

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [ ] Tests pass (if test suite exists)
- [x] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

**Workflow steps** (each gated with `if: steps.X.outcome == 'success'`):
1. `validate-environment` — validates the runner environment
2. `actions/checkout` — checks out the target repository
3. `setup-tool` — installs betterleaks
4. `actions/checkout` — checks out `config-repo` into `shared/`
5. `mkdir -p .github/report` — prepares the report directory
6. `betterleaks protect` — runs the scan; fails fast on non-zero exit
7. `upload-artifact` — uploads the JSON report only on failure

Permissions: `contents: read` only. All external actions are SHA-pinned.
