### PR TITLE
ci(workflows): add reusable actionlint workflow

### DIFF
--- a/.github/workflows/ci-qa-actionlint.yml
+++ b/.github/workflows/ci-qa-actionlint.yml
@@ -1,0 +1,86 @@
+# src: ./.github/workflows/ci-qa-actionlint.yml
+# @(#) : Reusable workflow for GitHub Actions workflow linting with actionlint
+#
+# Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+name: "CI QA Actionlint"
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      actionlint-version:
+        description: "Version of actionlint to install"
+        required: false
+        default: "1.7.12"
+        type: string
+      config-file:
+        description: "Path to the actionlint configuration file"
+        required: false
+        default: "./shared/configs/actionlint.yaml"
+        type: string
+
+jobs:
+  qa-actionlint:
+    name: Actionlint Workflow QA
+    runs-on: ubuntu-slim
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout target repository
+        id: target-checkout
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Validate environment
+        id: env-validation
+        if: steps.target-checkout.outcome == 'success'
+        uses: ./.github/actions/validate-environment
+        with:
+          actions-type: read
+
+      - name: Install actionlint
+        id: tool-install
+        if: steps.env-validation.outcome == 'success'
+        uses: ./.github/actions/setup-tool
+        with:
+          repo: rhysd/actionlint
+          tool-version: ${{ inputs.actionlint-version }}
+
+      - name: Checkout actionlint config
+        id: config-checkout
+        if: steps.tool-install.outcome == 'success'
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          repository: aglabo/.github
+          path: shared
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Prepare report directory
+        id: prepare-report
+        if: steps.config-checkout.outcome == 'success'
+        run: mkdir -p .github/report
+
+      - name: Run actionlint
+        id: lint-execute
+        if: steps.prepare-report.outcome == 'success'
+        run: |
+          actionlint -config-file "${{ inputs.config-file }}" 2>&1 | tee .github/report/actionlint-report.txt
+          exit "${PIPESTATUS[0]}"
+
+      - name: Upload actionlint report
+        id: report-upload
+        if: failure() && steps.lint-execute.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: actionlint-report
+          path: .github/report/actionlint-report.txt
+          retention-days: 30

--- a/.github/workflows/ci-workflows-qa.yml
+++ b/.github/workflows/ci-workflows-qa.yml
@@ -32,7 +32,7 @@ jobs:
     name: Actionlint
     permissions:
       contents: read
-    uses: aglabo/.github/.github/workflows/ci-common-lint-actionlint.yml@38070c03acff350b4c8f46d684781052b70c0e58 # r1.1.2
+    uses: ./.github/workflows/ci-qa-actionlint.yml
 
   ghalint:
     name: Ghalint

--- a/docs/.deckrd/reusable-workflows/actionlint/implementation/implementation.md
+++ b/docs/.deckrd/reusable-workflows/actionlint/implementation/implementation.md
@@ -1,0 +1,164 @@
+---
+title: "Implementation Plan: Actionlint Reusable Workflow"
+based-on: specifications.md v1.0.0
+status: Draft
+---
+
+<!-- markdownlint-disable line-length -->
+
+## 1. Overview
+
+### 1.1 Purpose
+
+This implementation plan delivers a reusable GitHub Actions workflow for running actionlint scans from caller repositories. The workflow will be added at `.github/workflows/ci-qa-actionlint.yml` and will support reusable invocation through `workflow_call` only.
+
+The workflow implements the following behavioral units in sequence:
+
+- `target-checkout-step` (persist-credentials: false)
+- `env-validation-step`
+- `tool-install-step`
+- `config-checkout-step` (fixed to aglabo/.github, fetch-depth: 1)
+- `prepare-report-step`
+- `lint-execute-step` (with report output via tee)
+- `report-upload-step` (on failure only)
+
+The workflow will enforce read-only repository access with `contents: read` at both the top-level workflow permissions block and the job-level permissions block.
+
+The caller workflow `ci-workflows-qa.yml` will be updated in Phase 2 to replace the external `aglabo/.github` actionlint job with a call to the new local reusable workflow.
+
+### 1.2 Reference
+
+- Prior Art / Reference PR: `ci-scan-betterleaks.yml` (same structural pattern)
+- Specifications: `specifications.md`
+- Output workflow file: `.github/workflows/ci-qa-actionlint.yml`
+
+---
+
+## 2. Implementation Plan
+
+### Phase 1: Reusable Workflow YAML
+
+#### Commit 1: ci(workflows/qa-actionlint): add reusable actionlint scanning workflow
+
+- Create `.github/workflows/ci-qa-actionlint.yml`.
+
+- Add the reusable workflow skeleton:
+  -- Set `name` to a descriptive Actionlint reusable workflow name.
+  -- Add top-level `permissions`.
+  -- Set `permissions.contents` to `read`.
+  -- Add a single job `qa-actionlint`.
+  -- Add job-level `permissions`.
+  -- Set job-level `permissions.contents` to `read`.
+  -- Set `runs-on` to `ubuntu-slim`.
+  -- Set `timeout-minutes` to `10`.
+
+- Add trigger under `on`:
+  -- Add `workflow_call` only (no `workflow_dispatch`).
+  -- Define inputs under `on.workflow_call.inputs`.
+
+- Add input `actionlint-version`:
+  -- Set `required: false`.
+  -- Set `type: string`.
+  -- Set `default: "1.7.12"`.
+  -- Reference as `${{ inputs.actionlint-version }}`.
+
+- Add input `config-file`:
+  -- Set `required: false`.
+  -- Set `type: string`.
+  -- Set `default: "./shared/configs/actionlint.yaml"`.
+  -- Reference as `${{ inputs.config-file }}`.
+
+- Add step ID `target-checkout` as the first step:
+  -- Use `actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3`.
+  -- Do not set `path` (checks out caller repository to workspace root).
+  -- Set `with.persist-credentials: false`.
+  -- Do not add an `if` condition to this first step.
+
+- Add step ID `env-validation` after `target-checkout`:
+  -- Use the local validate-environment composite action at path `./.github/actions/validate-environment`.
+  -- Set `with.actions-type: read`.
+  -- Add `if: steps.target-checkout.outcome == 'success'`.
+
+- Add step ID `tool-install` after `env-validation`:
+  -- Use the local setup-tool composite action at path `./.github/actions/setup-tool`.
+  -- Set `with.repo: rhysd/actionlint`.
+  -- Set `with.tool-version: ${{ inputs.actionlint-version }}`.
+  -- Add `if: steps.env-validation.outcome == 'success'`.
+
+- Add step ID `config-checkout` after `tool-install`:
+  -- Use `actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3`.
+  -- Set `with.repository: aglabo/.github` (fixed, not an input).
+  -- Set `with.path: shared`.
+  -- Set `with.fetch-depth: 1`.
+  -- Set `with.persist-credentials: false`.
+  -- Add `if: steps.tool-install.outcome == 'success'`.
+
+- Add step ID `prepare-report` after `config-checkout`:
+  -- Use a shell `run` step: `mkdir -p .github/report`.
+  -- Add `if: steps.config-checkout.outcome == 'success'`.
+
+- Add step ID `lint-execute` after `prepare-report`:
+  -- Use a shell `run` step with `tee` and `PIPESTATUS` pattern:
+  `actionlint -config-file ${{ inputs.config-file }} 2>&1 | tee .github/report/actionlint-report.txt; exit ${PIPESTATUS[0]}`
+  -- Add `if: steps.prepare-report.outcome == 'success'`.
+  -- Do not add `continue-on-error`.
+
+- Add step ID `report-upload` after `lint-execute`:
+  -- Use `actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1`.
+  -- Set `if: failure() && steps.lint-execute.outcome == 'failure'`.
+  -- Set `with.name: actionlint-report`.
+  -- Set `with.path: .github/report/actionlint-report.txt`.
+  -- Set `with.retention-days: 30`.
+
+- Final step order and gating summary:
+
+  | Step ID         | if condition                                           |
+  | --------------- | ------------------------------------------------------ |
+  | target-checkout | (none)                                                 |
+  | env-validation  | `steps.target-checkout.outcome == 'success'`           |
+  | tool-install    | `steps.env-validation.outcome == 'success'`            |
+  | config-checkout | `steps.tool-install.outcome == 'success'`              |
+  | prepare-report  | `steps.config-checkout.outcome == 'success'`           |
+  | lint-execute    | `steps.prepare-report.outcome == 'success'`            |
+  | report-upload   | `failure() && steps.lint-execute.outcome == 'failure'` |
+
+- Expected behavior after this commit:
+  -- Callable via `workflow_call` only.
+  -- Checks out the caller repository with `persist-credentials: false`.
+  -- Validates the environment for read-only actions usage.
+  -- Installs actionlint from `rhysd/actionlint` using the configured version (default: `1.7.12`).
+  -- Checks out `aglabo/.github` (fixed) with `fetch-depth: 1` into `shared/`.
+  -- Creates `.github/report/` directory before linting.
+  -- Runs actionlint with the resolved `config-file` and writes output to `.github/report/actionlint-report.txt`.
+  -- Fails immediately when actionlint reports a non-zero exit.
+  -- Uploads the artifact `actionlint-report` only when lint fails.
+  -- Operates with `contents: read` at both top-level and job-level.
+  -- Enforces `timeout-minutes: 10` at the job level.
+
+---
+
+### Phase 2: Caller Workflow Update
+
+#### Commit 2: ci(workflows/ci-workflows-qa): replace external actionlint with local reusable workflow
+
+- Edit `.github/workflows/ci-workflows-qa.yml`.
+
+- Update the `actionlint` job:
+  -- Replace `uses: aglabo/.github/.github/workflows/ci-common-lint-actionlint.yml@38070c03acff350b4c8f46d684781052b70c0e58 # r1.1.2`
+  with `uses: ./.github/workflows/ci-qa-actionlint.yml`.
+  -- Remove the external commit hash pin (no longer needed for a local reference).
+  -- Do not add a `with:` block (use all default input values).
+  -- Retain `permissions: contents: read` at the job level.
+
+- Expected behavior after this commit:
+  -- The `actionlint` job in `ci-workflows-qa.yml` calls the local reusable workflow.
+  -- No dependency on `aglabo/.github` for actionlint linting.
+  -- All actionlint behavior is governed by `ci-qa-actionlint.yml`.
+
+---
+
+## 3. Change History
+
+| Date       | Version | Description                 |
+| ---------- | ------- | --------------------------- |
+| 2026-06-12 | 1.0     | Initial implementation plan |

--- a/docs/.deckrd/reusable-workflows/actionlint/requirements/requirements.md
+++ b/docs/.deckrd/reusable-workflows/actionlint/requirements/requirements.md
@@ -1,0 +1,317 @@
+---
+id: REQ-001
+title: Requirements: Actionlint Reusable Workflow
+  module: reusable-workflows/actionlint
+  status: Draft
+  version: "1.0"
+  created: 2026-06-12
+---
+
+# Requirements: Actionlint Reusable Workflow
+
+## 1. Overview
+
+### Purpose
+
+外部の `aglabo/.github` ワークフローに依存しない独立した GitHub Actions ワークフローとして、
+actionlint ベースの GitHub Actions ワークフロー構文検証を実行する。
+
+### Scope
+
+- reusable な GitHub Actions ワークフローの提供
+- `workflow_call` トリガーのサポート
+- GitHub Actions 環境の検証（`validate-environment` action 使用）
+- `setup-tool` action による actionlint インストール
+- 設定リポジトリ `aglabo/.github` を `./shared/` にチェックアウト（固定）
+- `config-file` 入力パラメータで設定ファイルパスを指定（デフォルト: `./shared/configs/actionlint.yaml`、上書き可能）
+- lint エラー検出時のレポートファイル生成とアーティファクトアップロード
+
+### Out of Scope
+
+- ghalint スキャン（別ワークフローで対応）
+- セルフホスト以外のランナー対応
+- Windows / macOS ランナー対応
+
+---
+
+## 2. Context
+
+### Target Environment
+
+- GitHub Actions 環境
+- ランナー: `ubuntu-slim`（セルフホスト）
+- 言語: YAML (GitHub Actions workflow syntax)
+
+### Related Components
+
+| コンポーネント         | パス                                    | 役割                                                                                       |
+| ---------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------ |
+| validate-environment   | `.github/actions/validate-environment`  | 環境検証 composite action                                                                  |
+| setup-tool             | `.github/actions/setup-tool`            | バイナリインストール composite action                                                      |
+| actionlint 設定        | `shared/configs/actionlint.yaml`        | lint ルール設定（`config-repo` から `./shared/` にチェックアウト後、`config-file` で指定） |
+| 呼び出し元ワークフロー | `.github/workflows/ci-workflows-qa.yml` | このワークフローを使用                                                                     |
+
+### Assumptions
+
+- `ubuntu-slim` ランナーが利用可能
+- `rhysd/actionlint` リポジトリに GitHub Releases が存在する
+- `aglabo/.github` リポジトリに `configs/actionlint.yaml` が存在する
+- `setup-tool` action が actionlint バイナリを正常にインストールできる
+
+### System Context Diagram
+
+```text
+[呼び出し元ワークフロー]
+        |
+        | workflow_call
+        v
+[ci-lint-actionlint.yml]
+        |
+        +-- [actions/checkout] ─────── ターゲットリポジトリ checkout
+        |
+        +-- [validate-environment] ── 環境検証
+        |
+        +-- [setup-tool] ──────────── actionlint インストール (rhysd/actionlint)
+        |
+        +-- [actions/checkout] ─────── config-repo (aglabo/.github) を ./shared/ にチェックアウト
+        |                              fetch-depth: 1, persist-credentials: false
+        |
+        +-- [actionlint 実行] ──────── デフォルト動作でワークフローファイルを検証
+        |                              設定: shared/configs/actionlint.yaml
+        |
+        +-- [upload-artifact] ──────── エラー時のみ lint レポートをアップロード
+```
+
+---
+
+## 3. Design Decisions
+
+| ID    | Decision                                                                                                                                                                                         | Rationale                                                                                                            |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| DR-01 | 外部 `aglabo/.github` への依存を排除し、ローカル reusable workflow として実装する                                                                                                                | 外部依存によるバージョン管理リスクと可用性問題を解消する                                                             |
+| DR-02 | `workflow_call` トリガーのみをサポートする（`workflow_dispatch` は含めない）                                                                                                                     | lint ワークフローは CI トリガーからのみ呼び出すことを明確にする                                                      |
+| DR-03 | ローカルの `validate-environment` および `setup-tool` action を使用する                                                                                                                          | 外部 action への依存を排除し、プラットフォーム内で完結させる                                                         |
+| DR-04 | actionlint バイナリは `setup-tool` action で GitHub Releases からインストールする                                                                                                                | betterleaks と同一のツールインストールパターンを踏襲する                                                             |
+| DR-05 | 設定リポジトリは `aglabo/.github` に固定して `./shared/` にチェックアウトする。設定ファイルパスは `config-file` 入力パラメータで指定し、デフォルト値は `./shared/configs/actionlint.yaml` とする | チェックアウト元を固定することで設定の一元管理を保証しつつ、`config-file` の上書きで別の設定ファイルも指定可能にする |
+| DR-06 | lint エラー検出時はレポートファイルを生成してアーティファクトとしてアップロードする                                                                                                              | エラー内容を CI 外でも確認できるようにする                                                                           |
+| DR-07 | ステップ間の条件は `steps.<id>.outcome == 'success'` パターンを使用する                                                                                                                          | プロジェクト規約（`outputs.status != 'error'` 禁止）に準拠する                                                       |
+| DR-08 | `timeout-minutes`、`persist-credentials: false`、`permissions: contents: read` を明示的に設定する                                                                                                | ghalint の検証を通過し、セキュリティベストプラクティスに準拠する                                                     |
+
+---
+
+## 4. Functional Requirements
+
+### REQ-F-001: 環境検証
+
+**WHEN** ワークフローが開始されたとき、
+**THE SYSTEM SHALL** `validate-environment` action を使用して runner と権限を検証する。
+**IF** 検証が失敗した場合は後続ステップを実行しない。
+
+### REQ-F-002: ツールインストール
+
+**WHEN** 環境検証が成功したとき、
+**THE SYSTEM SHALL** `setup-tool` action を使用して `rhysd/actionlint` の指定バージョンをインストールする。
+**THE SYSTEM SHALL** デフォルトバージョン `1.7.12` を使用する（入力で上書き可能）。
+
+### REQ-F-003: 設定リポジトリのチェックアウト
+
+**WHEN** actionlint のインストールが成功したとき、
+**THE SYSTEM SHALL** `aglabo/.github` を `./shared/` にチェックアウトする（リポジトリ固定）。
+チェックアウト時は `fetch-depth: 1`、`persist-credentials: false` を設定する。
+
+### REQ-F-003b: ワークフロー検証実行
+
+**WHEN** 設定リポジトリのチェックアウトが成功したとき、
+**THE SYSTEM SHALL** actionlint のデフォルト動作に従って対象ファイルを検証する。
+**THE SYSTEM SHALL** `config-file` 入力パラメータで指定されたパスの設定ファイルを使用する。
+デフォルト値は `./shared/configs/actionlint.yaml` とし、呼び出し元が別パスに上書き可能とする。
+
+### REQ-F-004: lint 失敗時の即座の失敗
+
+**WHEN** actionlint がエラーを検出したとき、
+**THE SYSTEM SHALL** ワークフローを即座に失敗させる（exit code 1）。
+
+### REQ-F-005: lint レポート出力
+
+**WHEN** actionlint を実行したとき、
+**THE SYSTEM SHALL** lint 結果を `.github/report/actionlint-report.txt` に出力する。
+
+### REQ-F-006: エラー時のレポートアップロード
+
+**WHEN** actionlint がエラーを検出したとき、
+**THE SYSTEM SHALL** レポートファイルをアーティファクト `actionlint-report` としてアップロードする。
+保持期間: 30 日間。
+
+### REQ-F-007: ワークフロートリガー
+
+**THE SYSTEM SHALL** `workflow_call` トリガーをサポートする。
+
+### REQ-F-008: チェックアウト設定
+
+**WHEN** リポジトリをチェックアウトするとき、
+**THE SYSTEM SHALL** `persist-credentials: false` を設定する。
+
+### REQ-F-009: ジョブタイムアウト
+
+**THE SYSTEM SHALL** ジョブの `timeout-minutes` を `10` に固定する。
+入力パラメータによる上書きは不可とする。
+
+---
+
+## 5. Non-Functional Requirements
+
+### REQ-NF-001: 保守性
+
+ワークフローの各ステップは単一責任を持ち、独立して理解・修正できること。
+
+### REQ-NF-002: セキュリティ（最小権限）
+
+ジョブの権限は `contents: read` のみとする。追加権限は付与しない。
+
+### REQ-NF-003: 再現性
+
+`actionlint-version` 入力によりバージョンを固定可能とし、CI の再現性を確保する。
+
+### REQ-NF-004: 観察性
+
+lint エラー発生時にレポートアーティファクトを通じて問題内容を確認できること。
+
+### REQ-NF-005: 一貫性
+
+betterleaks reusable workflow と同一のステップ構造・命名規則・条件分岐パターンを使用する。
+
+---
+
+## 6. Constraints
+
+### REQ-C-001: ランナー
+
+`ubuntu-slim`（セルフホスト）ランナーを使用する。
+
+### REQ-C-002: 権限
+
+ワークフローレベルおよびジョブレベルで `contents: read` を明示的に設定する。
+
+### REQ-C-003: バージョン形式
+
+`actionlint-version` 入力は `X.Y.Z` 形式（セマンティックバージョニング）とする。
+
+### REQ-C-004: ローカルアクションのみ使用
+
+ステップでは `validate-environment`、`setup-tool` のローカル composite action のみを使用する。
+外部 GitHub Actions は `actions/checkout`、`actions/upload-artifact` のみ許可する。
+
+### REQ-C-005: 設定ファイルパス
+
+`config-file` 入力パラメータのデフォルト値は `./shared/configs/actionlint.yaml` とする。
+呼び出し元が明示的に上書きすることで `./shared/` 配下の別パスを指定可能とする。
+チェックアウト元リポジトリ（`aglabo/.github`）は固定であり入力パラメータによる変更は不可とする。
+
+### REQ-C-006: ステップ条件
+
+ステップの実行条件には `steps.<id>.outcome == 'success'` パターンを使用する。
+
+### REQ-C-007: 認証情報の保持禁止
+
+`actions/checkout` では `persist-credentials: false` を設定する。
+
+### REQ-C-008: タイムアウト設定
+
+ジョブの `timeout-minutes` は `10` に固定する。入力パラメータによる変更は不可。
+
+---
+
+## 7. User Stories
+
+### US-001: プラットフォームエンジニア
+
+**As** プラットフォームエンジニアとして、
+**I want** actionlint の reusable workflow をローカルに実装したい、
+**So that** 外部リポジトリへの依存なしに GitHub Actions 構文検証を CI に組み込める。
+
+### US-002: リポジトリメンテナー
+
+**As** リポジトリメンテナーとして、
+**I want** `workflow_call` で actionlint を実行したい、
+**So that** push や PR 時に自動で Actions ワークフローの構文エラーを検出できる。
+
+### US-003: 開発者
+
+**As** 開発者として、
+**I want** lint エラー時にレポートをダウンロードしたい、
+**So that** CI ログを参照せずにエラー詳細を確認できる。
+
+### US-004: セキュリティエンジニア
+
+**As** セキュリティエンジニアとして、
+**I want** ワークフローが最小権限で動作することを確認したい、
+**So that** CI パイプラインのセキュリティリスクを最小化できる。
+
+---
+
+## 8. Acceptance Criteria
+
+### AC-001: Reusable Workflow が正常に実行される
+
+```gherkin
+Given リポジトリに .github/workflows/*.yml が存在する
+And   configs/actionlint.yaml が存在する
+When  workflow_call で ci-lint-actionlint.yml が呼び出される
+Then  actionlint が .github/workflows/*.yml を検証する
+And   lint エラーがなければワークフローが成功する
+```
+
+### AC-002: デフォルトバージョンが使用される
+
+```gherkin
+Given actionlint-version 入力が省略されている
+When  ワークフローが実行される
+Then  actionlint 1.7.12 がインストールされる
+```
+
+### AC-003: lint エラー時にワークフローが失敗する
+
+```gherkin
+Given .github/workflows/ 内にシンタックスエラーのある YAML が存在する
+When  ワークフローが実行される
+Then  actionlint がエラーを検出しワークフローが失敗する
+And   レポートファイルがアーティファクトとしてアップロードされる
+```
+
+### AC-004: 環境検証失敗が後続ステップをブロックする
+
+```gherkin
+Given validate-environment が失敗する
+When  ワークフローが実行される
+Then  actionlint のインストールおよび実行ステップがスキップされる
+```
+
+### AC-005: カスタム設定ファイルが使用される
+
+```gherkin
+Given config-file 入力に "./configs/custom-actionlint.yaml" が指定されている
+When  ワークフローが実行される
+Then  actionlint がカスタム設定ファイルを使用して実行される
+```
+
+---
+
+## 9. Open Questions
+
+| ID    | Question                                                             | Status                                 |
+| ----- | -------------------------------------------------------------------- | -------------------------------------- |
+| OQ-01 | actionlint の出力形式（デフォルト出力 vs JSON 等）はどれを採用するか | 解決済み: テキスト形式（`.txt`）を採用 |
+| OQ-02 | `workflow_dispatch` を将来的に追加する可能性はあるか                 | 未解決（現在は含めない）               |
+
+---
+
+## 10. Change History
+
+| Version | Date       | Description                                                                                                                      |
+| ------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| 1.5     | 2026-06-12 | config-repo を aglabo/.github に固定（入力パラメータ廃止）、config-file のみ上書き可能に確定                                     |
+| 1.4     | 2026-06-12 | config-file 入力パラメータ追加（デフォルト: shared/configs/actionlint.yaml）、config-repo チェックアウトと組み合わせる設計に確定 |
+| 1.3     | 2026-06-12 | 設定ファイルを aglabo/.github から取得する方式に変更（betterleaks 同様の config-repo チェックアウト）                            |
+| 1.2     | 2026-06-12 | timeout-minutes を固定値 10 分に変更（入力パラメータ廃止）                                                                       |
+| 1.1     | 2026-06-12 | ghalint 対応要件追加: timeout-minutes, persist-credentials: false, permissions 明示                                              |
+| 1.0     | 2026-06-12 | 初版作成（rev コマンドによるリバースエンジニアリング）                                                                           |

--- a/docs/.deckrd/reusable-workflows/actionlint/specifications/specifications.md
+++ b/docs/.deckrd/reusable-workflows/actionlint/specifications/specifications.md
@@ -1,0 +1,353 @@
+---
+title: "Design Specification: Actionlint Reusable Workflow"
+based-on: requirements.md v1.5
+status: Draft
+---
+
+<!-- markdownlint-disable line-length -->
+
+## 1. Overview
+
+### 1.1 Purpose
+
+This specification defines the behavioral design for the Actionlint reusable workflow. It describes workflow inputs, validation behavior, installation behavior, external configuration resolution, lint execution, report generation, and failure semantics.
+
+<!-- impl-note: Module path: reusable-workflows/actionlint -->
+
+### 1.2 Scope
+
+This specification covers the reusable workflow behavior from trigger input resolution through environment validation, tool installation, configuration checkout, lint execution, and optional report upload.
+
+It defines observable workflow behavior only. Implementation-specific action wiring, exact YAML syntax, and local file layout are implementation details unless carried in `impl-note` comments.
+
+---
+
+## 2. Design Principles
+
+### 2.1 Classification Philosophy
+
+The workflow SHALL be treated as a fail-fast quality gate.
+
+Each unit SHALL have a single behavioral responsibility:
+
+| Unit            | Responsibility                                                         |
+| --------------- | ---------------------------------------------------------------------- |
+| trigger-inputs  | Resolve caller-provided inputs and defaults                            |
+| target-checkout | Check out the target repository into the workspace                     |
+| env-validation  | Verify the runner and workflow environment before downstream execution |
+| tool-install    | Install the linter tool into the executable search path                |
+| config-checkout | Retrieve the shared linter configuration source                        |
+| lint-execute    | Execute the linter and write results to a report file                  |
+| report-upload   | Upload the lint report as an artifact on failure only                  |
+
+### 2.2 Design Assumptions
+
+| Assumption                    | Description                                                                                              |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Hosted runner compatibility   | The workflow runs on a Linux hosted runner compatible with actionlint and local composite actions.       |
+| Read-only repository access   | The workflow requires repository read access only.                                                       |
+| External configuration source | Linter configuration is obtained from the fixed shared repository `aglabo/.github`, not from the caller. |
+| Fixed checkout path           | The configuration source is always checked out into the `shared/` directory.                             |
+| Fixed config repo             | The configuration repository is fixed to `aglabo/.github` and is not caller-configurable.                |
+| Linter failure semantics      | A non-zero linter exit status represents a workflow failure.                                             |
+| No published outputs          | The workflow communicates success or failure through job status only.                                    |
+| Fixed timeout                 | The job timeout is fixed at 10 minutes and is not caller-configurable.                                   |
+
+### 2.3 External Design Summary
+
+#### Feature Decomposition
+
+| Unit            | Pre-Conditions                   | Post-Conditions                                                   | Failure Behavior                                       |
+| --------------- | -------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------ |
+| trigger-inputs  | Workflow has been invoked        | Effective linter version and configuration file path are resolved | SHALL NOT fail under normal input omission             |
+| target-checkout | Inputs resolved                  | Source code is available in the workspace                         | SHALL block all downstream units on checkout error     |
+| env-validation  | Target checkout succeeded        | Environment status is successful                                  | SHALL block all downstream units on validation error   |
+| tool-install    | Environment validation succeeded | Linter is available in the executable search path                 | SHALL fail the job on installation error               |
+| config-checkout | Tool installation succeeded      | Shared linter configuration source is available at `shared/`      | SHALL fail the job when the source cannot be retrieved |
+| lint-execute    | Configuration checkout completed | Linter exits and report file is written                           | SHALL fail immediately on non-zero linter exit         |
+| report-upload   | lint-execute failed              | Lint report artifact is uploaded                                  | Non-fatal; workflow is already failed at lint-execute  |
+
+<!-- impl-note: Local env-validation composite action inputs: architecture=amd64, actions-type=read, require-github-hosted=false. -->
+<!-- impl-note: Local setup-tool composite action inputs: repo=rhysd/actionlint, tool-version=${{ inputs.actionlint-version }}. -->
+<!-- impl-note: Configuration checkout path: shared/. Required linter config: shared/configs/actionlint.yaml (default). -->
+
+#### Unit Interaction Map
+
+```text
++----------------+
+| trigger-inputs |
++-------+--------+
+        |
+        v
++-----------------+
+| target-checkout |
++-------+---------+
+        |
+        v
++----------------+
+| env-validation |
++-------+--------+
+        |
+        v
++----------------+
+|  tool-install  |
++-------+--------+
+        |
+        v
++-----------------+
+| config-checkout |
++-------+---------+
+        |
+        v
++----------------+     +---------------+
+|  lint-execute  | --> | report-upload |
++----------------+     | (failure only)|
+                       +---------------+
+```
+
+#### Data Flow Diagram
+
+```text
+Caller Inputs
+  | actionlint-version
+  | config-file
+  v
++----------------+
+| trigger-inputs |
++-------+--------+
+        |
+        | effective linter version
+        | effective config file path
+        v
++-----------------+
+| target-checkout |
++-------+---------+
+        | success
+        v
++----------------+
+| env-validation |
++-------+--------+
+        | success
+        v
++----------------+
+|  tool-install  |
++-------+--------+
+        | success
+        v
++-----------------+
+| config-checkout |
++-------+---------+
+        | success
+        v
++----------------+
+|  lint-execute  |
++-------+--------+
+        |
+        +-- success --> Workflow Status: success
+        |
+        +-- failure --> +---------------+
+                        | report-upload |
+                        +---------------+
+                              |
+                              v
+                        Workflow Status: failed
+```
+
+### 2.4 Non-Goals
+
+| Non-Goal                                     | Reason                                                                   |
+| -------------------------------------------- | ------------------------------------------------------------------------ |
+| Publishing workflow outputs                  | The workflow is fail-fast only and has no output contract.               |
+| Supporting caller-local linter configuration | The configuration source is fixed and external to the caller repository. |
+| Supporting a configuration repository input  | The configuration repository is fixed to `aglabo/.github`.               |
+| Requesting write permissions                 | The workflow requires read-only repository access.                       |
+| Continuing after linter failure              | Linter failure SHALL fail the workflow immediately.                      |
+| Delegating to an external reusable workflow  | The architecture uses local composite actions only.                      |
+| Caller-configurable timeout                  | The job timeout is fixed at 10 minutes.                                  |
+
+### 2.5 Behavioral Design Decisions
+
+| ID     | Decision                                                                                               | Rationale                                                                                   | Affected Rules | Status   |
+| ------ | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- | -------------- | -------- |
+| DD-001 | The workflow SHALL resolve missing linter version input to the default stable version `1.7.12`.        | Callers should be able to use the workflow without specifying a version.                    | R-001          | Accepted |
+| DD-002 | The workflow SHALL resolve missing config-file input to `./shared/configs/actionlint.yaml`.            | The default path provides organization-wide linter policy from the fixed config repository. | R-002          | Accepted |
+| DD-003 | Environment validation SHALL run before installation and linting.                                      | Invalid runtime conditions should stop the workflow before side effects or lint work occur. | R-003, R-004   | Accepted |
+| DD-004 | Tool installation SHALL be gated by successful environment validation.                                 | Installation should occur only in a validated environment.                                  | R-005, R-006   | Accepted |
+| DD-005 | Configuration checkout SHALL be gated by successful tool installation.                                 | Configuration should be retrieved only when linting can proceed.                            | R-007, R-008   | Accepted |
+| DD-006 | Lint execution SHALL be gated by completed configuration checkout.                                     | The linter requires the shared configuration source.                                        | R-009, R-010   | Accepted |
+| DD-007 | Linter non-zero exit SHALL fail the workflow immediately.                                              | Lint errors are blocking quality gate failures.                                             | R-011          | Accepted |
+| DD-008 | Workflow permissions SHALL be limited to read-only repository content access.                          | The workflow does not require mutation privileges.                                          | R-012          | Accepted |
+| DD-009 | The configuration repository SHALL be fixed to `aglabo/.github` and not caller-configurable.           | Centralizing config management prevents per-caller policy divergence.                       | R-007          | Accepted |
+| DD-010 | The config-file path SHALL be caller-overridable with a default of `./shared/configs/actionlint.yaml`. | Allows callers to reference a different config within the checked-out `shared/` directory.  | R-002, R-009   | Accepted |
+| DD-011 | The job timeout SHALL be fixed at 10 minutes and not caller-configurable.                              | Lint jobs are expected to complete quickly; a fixed timeout prevents runaway jobs.          | R-013          | Accepted |
+| DD-012 | The lint report SHALL be uploaded as an artifact on failure only.                                      | Preserves error details for investigation; avoids artifact storage on clean runs.           | R-017, R-018   | Accepted |
+
+### 2.6 Related Decision Records
+
+| DR ID | Decision                                                                  | Specification Impact                                                                        |
+| ----- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| DR-01 | Independent reusable workflow                                             | The workflow SHALL use local composition rather than external reusable workflow delegation. |
+| DR-02 | `workflow_call` trigger only                                              | The workflow SHALL support `workflow_call` invocation only.                                 |
+| DR-03 | Use local composite actions                                               | Tool installation and environment validation SHALL use local composite actions.             |
+| DR-04 | Linter version configurable via input with default                        | The linter version SHALL be caller-configurable and defaulted when omitted.                 |
+| DR-05 | Configuration from fixed external repository with caller-overridable path | Config repo is fixed; config file path is caller-overridable with a default.                |
+| DR-06 | Fail-fast on non-zero linter exit                                         | Lint failure SHALL fail the workflow immediately.                                           |
+| DR-07 | Step gating with `steps.<id>.outcome == 'success'`                        | Each unit SHALL be conditioned on the previous unit's `outcome` field.                      |
+| DR-08 | Security: timeout, persist-credentials, permissions                       | Fixed timeout, no persisted credentials, read-only permissions are required.                |
+
+### 2.7 DD to DR Promotion Criteria
+
+A design decision SHOULD be promoted to a decision record when any of the following are true:
+
+| Criterion              | Promotion Trigger                                                                               |
+| ---------------------- | ----------------------------------------------------------------------------------------------- |
+| Cross-module impact    | The decision affects other reusable workflows or shared composite actions.                      |
+| Public contract impact | The decision changes workflow inputs, permissions, triggers, or failure semantics.              |
+| Migration cost         | Reversing the decision would require caller changes.                                            |
+| Security posture       | The decision changes token usage, permissions, configuration source trust, or failure handling. |
+| Operational policy     | The decision encodes organization-wide CI policy.                                               |
+
+---
+
+## 3. Behavioral Specification
+
+### 3.1 Input Domain
+
+| Input              | Required | Default                            | Constraints                                                                          | Behavior                                      |
+| ------------------ | -------- | ---------------------------------- | ------------------------------------------------------------------------------------ | --------------------------------------------- |
+| actionlint-version | No       | `1.7.12`                           | SHALL use semantic version format `X.Y.Z` when explicitly supplied                   | Determines the linter version to install      |
+| config-file        | No       | `./shared/configs/actionlint.yaml` | SHALL be a valid path within the `shared/` directory after config-checkout completes | Determines the linter configuration file path |
+
+<!-- impl-note: actionlint-version maps to setup-tool tool-version and must satisfy X.Y.Z format. -->
+<!-- impl-note: config-file default is ./shared/configs/actionlint.yaml. The configuration source is always aglabo/.github checked out into shared/. -->
+<!-- impl-note: target-checkout uses persist-credentials: false. -->
+
+### 3.2 Output Semantics
+
+The workflow SHALL publish no reusable workflow outputs.
+
+The observable result SHALL be one of:
+
+| Result  | Meaning                                                                                        |
+| ------- | ---------------------------------------------------------------------------------------------- |
+| Success | All units completed successfully and the linter exited with status `0`.                        |
+| Failure | Environment validation, tool installation, configuration checkout, or linter execution failed. |
+
+On failure caused by lint errors, the workflow SHALL produce a text report artifact named `actionlint-report` at `.github/report/actionlint-report.txt`.
+
+### 3.3 Step Execution Semantics
+
+The workflow SHALL execute units in this order:
+
+```text
+trigger-inputs -> target-checkout -> env-validation -> tool-install -> config-checkout -> prepare-report -> lint-execute -> report-upload
+```
+
+Each executable unit after input resolution SHALL be conditioned on the previous unit succeeding.
+
+The lint execution unit SHALL fail fast. It MUST NOT ignore a non-zero linter exit status and MUST NOT continue on lint failure.
+
+<!-- impl-note: Step gating pattern: if: steps.<id>.outcome == 'success'. -->
+<!-- impl-note: Linter command: actionlint -config-file ${{ inputs.config-file }} 2>&1 | tee .github/report/actionlint-report.txt; exit ${PIPESTATUS[0]} -->
+<!-- impl-note: prepare-report step: mkdir -p .github/report -->
+<!-- impl-note: report-upload step: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3 -->
+<!-- impl-note: report-upload step: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1, if: failure() && steps.lint-execute.outcome == 'failure', name: actionlint-report, path: .github/report/actionlint-report.txt, retention-days: 30 -->
+<!-- impl-note: target-checkout and config-checkout both use actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3 -->
+<!-- impl-note: config-checkout: repository: aglabo/.github, path: shared, fetch-depth: 1, persist-credentials: false -->
+<!-- impl-note: job timeout-minutes: 10 (fixed) -->
+
+---
+
+## 4. Decision Rules
+
+| Rule ID | Step            | Condition                                                | Outcome                                                                                                                           |
+| ------- | --------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| R-001   | trigger-inputs  | `actionlint-version` is omitted                          | The workflow SHALL resolve the default linter version `1.7.12`.                                                                   |
+| R-002   | trigger-inputs  | `config-file` is omitted                                 | The workflow SHALL resolve the default configuration file path `./shared/configs/actionlint.yaml`.                                |
+| R-003   | env-validation  | Workflow execution has started                           | The workflow SHALL validate the runner and action environment before installation or linting.                                     |
+| R-004   | env-validation  | Environment validation reports an error status           | The workflow SHALL block tool installation, configuration checkout, and lint execution.                                           |
+| R-005   | tool-install    | Environment validation succeeded                         | The workflow SHALL install the requested linter version into the executable search path.                                          |
+| R-006   | tool-install    | Tool installation fails                                  | The workflow SHALL fail the job and SHALL NOT run configuration checkout or lint execution.                                       |
+| R-007   | config-checkout | Tool installation succeeded                              | The workflow SHALL checkout `aglabo/.github` into the `shared/` directory with `fetch-depth: 1` and `persist-credentials: false`. |
+| R-008   | config-checkout | The configuration source is inaccessible                 | The workflow SHALL fail the job and SHALL NOT run lint execution.                                                                 |
+| R-009   | lint-execute    | Configuration checkout completed                         | The workflow SHALL execute the linter using the resolved configuration file path.                                                 |
+| R-010   | lint-execute    | Resolved configuration file is absent or unusable        | The linter execution SHALL fail and the workflow SHALL fail immediately.                                                          |
+| R-011   | lint-execute    | Linter exits with a non-zero status                      | The workflow MUST fail immediately and MUST NOT continue on error.                                                                |
+| R-012   | workflow        | Workflow permissions are evaluated                       | The workflow SHALL request read-only repository contents permission at workflow and job level.                                    |
+| R-013   | workflow        | Job timeout is evaluated                                 | The job SHALL enforce a fixed timeout of 10 minutes.                                                                              |
+| R-014   | workflow        | A downstream unit is evaluated after an upstream failure | The downstream unit SHALL be skipped unless explicitly covered by fail-fast lint behavior.                                        |
+| R-015   | target-checkout | Checkout is performed                                    | The workflow SHALL set `persist-credentials: false` on the target repository checkout.                                            |
+| R-016   | prepare-report  | lint-execute is about to run                             | The workflow SHALL create the `.github/report/` directory before executing the linter.                                            |
+| R-017   | lint-execute    | Linter runs                                              | The workflow SHALL write lint results to `.github/report/actionlint-report.txt`.                                                  |
+| R-018   | report-upload   | lint-execute exits with non-zero status                  | The workflow SHALL upload `.github/report/actionlint-report.txt` as artifact `actionlint-report` on failure only.                 |
+| R-019   | report-upload   | lint-execute exits with status `0`                       | The workflow MUST NOT upload any artifact.                                                                                        |
+| R-020   | target-checkout | Checkout is performed                                    | The workflow SHALL declare step ID `target-checkout` explicitly on the first checkout step.                                       |
+| R-021   | trigger-inputs  | Inputs are declared                                      | Each workflow input SHALL include a non-empty `description` field.                                                                |
+| R-022   | workflow        | Workflow identity is declared                            | The workflow SHALL declare a non-empty `name` field at the top level.                                                             |
+
+---
+
+## 5. Edge Cases
+
+| Input / Condition                           | Behavior                                                             | REQ                  | Rationale                                                             |
+| ------------------------------------------- | -------------------------------------------------------------------- | -------------------- | --------------------------------------------------------------------- |
+| `actionlint-version` omitted                | The workflow SHALL use the default linter version `1.7.12`.          | REQ-F-002            | Callers should not need to know the current approved version.         |
+| `config-file` omitted                       | The workflow SHALL use `./shared/configs/actionlint.yaml`.           | REQ-F-003b           | Organization-wide policy should apply by default.                     |
+| `config-file` points to a non-existent path | Linter execution SHALL fail and the workflow SHALL fail immediately. | REQ-F-004            | Missing configuration is a blocking lint setup error.                 |
+| Explicit linter version is not available    | Tool installation SHALL fail the job.                                | REQ-C-003, REQ-C-004 | Invalid or unavailable versions cannot produce reliable lint results. |
+| Configuration source is inaccessible        | Configuration checkout SHALL fail the job.                           | REQ-F-003            | A lint run without configuration is not valid.                        |
+| Linter detects a syntax error               | Lint execution SHALL fail fast; report SHALL be uploaded.            | REQ-F-004, REQ-F-006 | Lint errors are blocking quality gate failures.                       |
+| Linter detects no errors                    | Workflow SHALL succeed; no artifact SHALL be uploaded.               | REQ-F-006            | Avoids unnecessary artifact storage on clean runs.                    |
+| Environment validation reports an error     | All downstream units SHALL be blocked.                               | REQ-F-001            | Invalid execution environments should stop before install or lint.    |
+| Caller expects workflow outputs             | No outputs SHALL be produced.                                        | Function Decisions   | The workflow communicates only by job status.                         |
+| `.github/report/` directory does not exist  | The workflow SHALL create it before running the linter.              | REQ-F-005            | Ensures the report output path exists before the linter writes to it. |
+
+---
+
+## 6. Requirements Traceability
+
+| REQ ID     | Rule IDs                   | Notes                                                                                                    |
+| ---------- | -------------------------- | -------------------------------------------------------------------------------------------------------- |
+| REQ-F-001  | R-003, R-004, R-014        | Environment validation runs before install and lint and blocks downstream failure paths.                 |
+| REQ-F-002  | R-001, R-005, R-006        | Linter installation uses the resolved version and fails the job on installation error.                   |
+| REQ-F-003  | R-007, R-008               | Configuration checkout is fixed to `aglabo/.github` into `shared/` with fetch-depth 1.                   |
+| REQ-F-003b | R-002, R-009, R-010        | Lint execution uses the resolved config-file path; fails on absent or unusable configuration.            |
+| REQ-F-004  | R-009, R-010, R-011        | Lint execution uses shared configuration and fails immediately on non-zero exit.                         |
+| REQ-F-005  | R-016, R-017               | Report directory is created before lint; lint results written to `.github/report/actionlint-report.txt`. |
+| REQ-F-006  | R-018, R-019               | Report uploaded as artifact on failure only; no upload on success.                                       |
+| REQ-F-007  | R-003 (workflow)           | `workflow_call` trigger only.                                                                            |
+| REQ-F-008  | R-015                      | `persist-credentials: false` on all checkout steps.                                                      |
+| REQ-F-009  | R-013                      | Job timeout fixed at 10 minutes.                                                                         |
+| REQ-NF-001 | R-003, R-005, R-007, R-009 | Each unit is represented by a separate named workflow step.                                              |
+| REQ-NF-002 | R-012                      | Permissions limited to read-only repository contents access.                                             |
+| REQ-NF-003 | R-001, R-005               | Linter version comes from input resolution.                                                              |
+| REQ-NF-004 | R-018                      | Lint report artifact enables error investigation without CI log access.                                  |
+| REQ-NF-005 | R-007, R-009               | Configuration location and source are deterministic.                                                     |
+| REQ-C-001  | R-003                      | Runner compatibility is validated before downstream execution.                                           |
+| REQ-C-002  | R-012                      | Read-only contents permission at workflow and job level.                                                 |
+| REQ-C-003  | R-001                      | `actionlint-version` input uses `X.Y.Z` semantic version format.                                         |
+| REQ-C-004  | R-003, R-005               | Local composite actions provide validation and installation behavior.                                    |
+| REQ-C-005  | R-002, R-007, R-009        | `config-file` default resolves to `./shared/configs/actionlint.yaml`.                                    |
+| REQ-C-006  | R-014                      | Step gating uses `steps.<id>.outcome == 'success'` pattern.                                              |
+| REQ-C-007  | R-015                      | `persist-credentials: false` on all `actions/checkout` steps.                                            |
+| REQ-C-008  | R-013                      | Job `timeout-minutes` fixed at 10.                                                                       |
+| REQ-NF-001 | R-020                      | Each step SHALL declare an explicit step ID.                                                             |
+| (implicit) | R-021                      | Each input SHALL include a description for maintainability.                                              |
+| (implicit) | R-022                      | The workflow SHALL declare a name for observability in the Actions UI.                                   |
+
+---
+
+## 7. Open Questions
+
+| # | Question                                             | Source    | Impact                          |
+| - | ---------------------------------------------------- | --------- | ------------------------------- |
+| 1 | `workflow_dispatch` を将来的に追加する可能性はあるか | REQ OQ-02 | Trigger section change if added |
+
+---
+
+## 8. Change History
+
+| Date       | Version | Change                                                                                  |
+| ---------- | ------- | --------------------------------------------------------------------------------------- |
+| 2026-06-12 | 1.1.0   | Add R-020 (step ID), R-021 (input description), R-022 (workflow name) from tasks review |
+| 2026-06-12 | 1.0.0   | Initial specification                                                                   |

--- a/docs/.deckrd/reusable-workflows/actionlint/tasks/tasks.md
+++ b/docs/.deckrd/reusable-workflows/actionlint/tasks/tasks.md
@@ -1,0 +1,362 @@
+---
+title: "Implementation Tasks"
+module: reusable-workflows/actionlint
+status: Active
+created: "2026-06-12 00:00:00"
+source: specifications.md
+---
+
+<!-- markdownlint-disable line-length -->
+
+各 task は単一ユニットテストケース（`it()` ブロック）に対応する。
+
+テスト手法: `actionlint`（CI）と `yq` 属性検査（ローカル開発者検証専用、ワークフロー内では使用しない）
+
+`yq:` 行はテスト作成者向けの実装ヒントであり、ワークフローステップではない。
+
+---
+
+## Task Summary
+
+| Test Target                  | Scenario Groups            | Case Count | Status      |
+| ---------------------------- | -------------------------- | ---------: | ----------- |
+| T-01: Workflow structure     | Normal / Error / Edge case |         11 | in progress |
+| T-02: Step chain             | Normal / Error / Edge case |         12 | in progress |
+| T-03: Failure propagation    | Error / Edge case          |          7 | in progress |
+| T-04: YAML static validation | Normal                     |          4 | in progress |
+| T-05: Config file and report | Normal / Error / Edge case |         10 | in progress |
+| **Total**                    | 17 scenario groups         |     **44** |             |
+
+---
+
+## T-01: Workflow Structure
+
+### [正常] Normal Cases
+
+#### T-01-01: Inputs and triggers are correctly defined
+
+- [x] **T-01-01-01**: `actionlint-version` が `required: false`、`type: string`、`default: "1.7.12"` で宣言されていること
+  - Target: `ci-qa-actionlint.yml` `.on.workflow_call.inputs.actionlint-version`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When inputs を検査する
+  - Expected: `required: false`、`type: string`、`default: "1.7.12"` がすべて設定されている
+  - `yq: yq '.on.workflow_call.inputs.actionlint-version' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-01-01-02**: `config-file` が `required: false`、`type: string`、`default: "./shared/configs/actionlint.yaml"` で宣言されていること
+  - Target: `ci-qa-actionlint.yml` `.on.workflow_call.inputs.config-file`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When inputs を検査する
+  - Expected: `required: false`、`type: string`、`default: "./shared/configs/actionlint.yaml"` がすべて設定されている
+  - `yq: yq '.on.workflow_call.inputs.config-file' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-01-01-03**: top-level permissions が `contents: read` のみであること
+  - Target: `ci-qa-actionlint.yml` `.permissions`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When top-level permissions を検査する
+  - Expected: `permissions.contents == 'read'` かつ他のキーが存在しない
+  - `yq: yq '.permissions' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-01-01-04**: job-level permissions が `contents: read` のみであること
+  - Target: `ci-qa-actionlint.yml` `.jobs.qa-actionlint.permissions`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When job-level permissions を検査する
+  - Expected: `jobs.qa-actionlint.permissions.contents == 'read'` かつ他のキーが存在しない
+  - `yq: yq '.jobs.qa-actionlint.permissions' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-01-01-05**: `timeout-minutes` が `10` に固定されていること
+  - Target: `ci-qa-actionlint.yml` `.jobs.qa-actionlint.timeout-minutes`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When job timeout を検査する
+  - Expected: `jobs.qa-actionlint.timeout-minutes == 10`
+  - `yq: yq '.jobs.qa-actionlint.timeout-minutes' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-01-01-06**: `runs-on` が `ubuntu-slim` であること
+  - Target: `ci-qa-actionlint.yml` `.jobs.qa-actionlint.runs-on`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When runner を検査する
+  - Expected: `jobs.qa-actionlint.runs-on == 'ubuntu-slim'`
+  - `yq: yq '.jobs.qa-actionlint.runs-on' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-01-01-07**: ワークフローに `name` フィールドが設定されていること
+  - Target: `ci-qa-actionlint.yml` `.name`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When name フィールドを検査する
+  - Expected: `.name` が非空文字列
+  - `yq: yq '.name' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-01-01-08**: `actionlint-version` と `config-file` に `description` フィールドが設定されていること
+  - Target: `ci-qa-actionlint.yml` `.on.workflow_call.inputs`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When input descriptions を検査する
+  - Expected: 両入力の `description` が非空文字列
+  - `yq: yq '.on.workflow_call.inputs | to_entries[] | {(.key): .value.description}' .github/workflows/ci-qa-actionlint.yml`
+
+### [異常] Error Cases
+
+#### T-01-02: Workflow does not expose outputs or unsupported triggers
+
+- [x] **T-01-02-01**: `on.workflow_call.outputs` が存在しないか空であること
+  - Target: `ci-qa-actionlint.yml` `.on.workflow_call.outputs`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When outputs を検査する
+  - Expected: `on.workflow_call.outputs` が null または空
+  - `yq: yq '.on.workflow_call.outputs' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-01-02-02**: `workflow_dispatch` トリガーが存在しないこと
+  - Target: `ci-qa-actionlint.yml` `.on`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When トリガーを検査する
+  - Expected: `.on` に `workflow_dispatch` キーが存在しない
+  - `yq: yq '.on | keys' .github/workflows/ci-qa-actionlint.yml`
+
+### [エッジケース] Edge Cases
+
+#### T-01-03: Input defaults are explicitly declared
+
+- [x] **T-01-03-01**: `actionlint-version` と `config-file` が `workflow_call` で非空デフォルトを持つこと
+  - Target: `ci-qa-actionlint.yml` `.on.workflow_call.inputs`
+  - Scenario: Given inputs が省略された状態で `workflow_call` が呼ばれる、When デフォルト値を検査する
+  - Expected: 両入力のデフォルト値が非空文字列
+  - `yq: yq '.on.workflow_call.inputs | to_entries[] | .value.default' .github/workflows/ci-qa-actionlint.yml`
+
+---
+
+## T-02: Step Chain
+
+### [正常] Normal Cases
+
+#### T-02-01: Each step exists with the correct ID, action reference, and gate condition
+
+- [x] **T-02-01-01**: `target-checkout` が `actions/checkout` を使用し、`if` 条件なし、`persist-credentials: false` を設定すること
+  - Target: `ci-qa-actionlint.yml` step `target-checkout`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When `target-checkout` ステップを検査する
+  - Expected: `uses` に `actions/checkout` を含み、`if` キーなし、`with.persist-credentials: false`
+  - `yq: yq '.jobs.qa-actionlint.steps[] | select(.id == "target-checkout")' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-02-01-01b**: `target-checkout` が step `id` として `target-checkout` を明示していること
+  - Target: `ci-qa-actionlint.yml` step `target-checkout`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When 最初の step の `id` を検査する
+  - Expected: `steps[0].id == 'target-checkout'`
+  - `yq: yq '.jobs.qa-actionlint.steps[0].id' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-02-01-02**: `env-validation` が `./.github/actions/validate-environment` を使用し、`if: steps.target-checkout.outcome == 'success'` でゲートされること
+  - Target: `ci-qa-actionlint.yml` step `env-validation`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When `env-validation` ステップを検査する
+  - Expected: `uses: ./.github/actions/validate-environment`、`with.actions-type: read`、`if: steps.target-checkout.outcome == 'success'`
+  - `yq: yq '.jobs.qa-actionlint.steps[] | select(.id == "env-validation")' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-02-01-03**: `tool-install` が `./.github/actions/setup-tool` を使用し、`repo: rhysd/actionlint`、`if: steps.env-validation.outcome == 'success'` でゲートされること
+  - Target: `ci-qa-actionlint.yml` step `tool-install`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When `tool-install` ステップを検査する
+  - Expected: `uses: ./.github/actions/setup-tool`、`with.repo: rhysd/actionlint`、`if: steps.env-validation.outcome == 'success'`
+  - `yq: yq '.jobs.qa-actionlint.steps[] | select(.id == "tool-install")' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-02-01-03b**: `tool-install` が `tool-version: ${{ inputs.actionlint-version }}` を渡すこと
+  - Target: `ci-qa-actionlint.yml` step `tool-install`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When `tool-install` の `tool-version` を検査する
+  - Expected: `with.tool-version == '${{ inputs.actionlint-version }}'`
+  - `yq: yq '.jobs.qa-actionlint.steps[] | select(.id == "tool-install") | .with.tool-version' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-02-01-04**: `config-checkout` が `actions/checkout` を使用し、`repository: aglabo/.github`、`path: shared`、`fetch-depth: 1`、`persist-credentials: false`、`if: steps.tool-install.outcome == 'success'` を持つこと
+  - Target: `ci-qa-actionlint.yml` step `config-checkout`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When `config-checkout` ステップを検査する
+  - Expected: `with.repository: aglabo/.github`、`with.path: shared`、`with.fetch-depth: 1`、`with.persist-credentials: false`、`if: steps.tool-install.outcome == 'success'`
+  - `yq: yq '.jobs.qa-actionlint.steps[] | select(.id == "config-checkout")' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-02-01-05**: `lint-execute` が `actionlint -config-file` コマンドを実行し、`if: steps.prepare-report.outcome == 'success'` でゲートされること
+  - Target: `ci-qa-actionlint.yml` step `lint-execute`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When `lint-execute` ステップを検査する
+  - Expected: `run` に `actionlint -config-file` と `tee .github/report/actionlint-report.txt` を含み、`if: steps.prepare-report.outcome == 'success'`
+  - `yq: yq '.jobs.qa-actionlint.steps[] | select(.id == "lint-execute")' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-02-01-06**: ステップ実行順が `target-checkout → env-validation → tool-install → config-checkout → prepare-report → lint-execute` であること
+  - Target: `ci-qa-actionlint.yml` `.jobs.qa-actionlint.steps`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When ステップ順序を検査する
+  - Expected: steps 配列内の ID が上記順序に従う
+  - `yq: yq '.jobs.qa-actionlint.steps[].id' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-02-01-07**: `report-upload` が `actions/upload-artifact` を使用していること
+  - Target: `ci-qa-actionlint.yml` step `report-upload`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When `report-upload` の `uses` を検査する
+  - Expected: `uses` に `actions/upload-artifact` を含む
+  - `yq: yq '.jobs.qa-actionlint.steps[] | select(.id == "report-upload") | .uses' .github/workflows/ci-qa-actionlint.yml`
+
+### [異常] Error Cases
+
+#### T-02-02: Lint step does not suppress failures
+
+- [x] **T-02-02-01**: `lint-execute` に `continue-on-error: true` がないこと
+  - Target: `ci-qa-actionlint.yml` step `lint-execute`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When `lint-execute` の `continue-on-error` を検査する
+  - Expected: `continue-on-error` キーが存在しないか `false`
+  - `yq: yq '.jobs.qa-actionlint.steps[] | select(.id == "lint-execute") | .continue-on-error' .github/workflows/ci-qa-actionlint.yml`
+
+### [エッジケース] Edge Cases
+
+#### T-02-03: If-conditions use only immediate-upstream outcome gates
+
+- [x] **T-02-03-01**: 各下流ステップが直前ステップの `outcome` のみにゲートされ、`always()`、`failure()`、`||` を含まないこと（`report-upload` を除く）
+  - Target: `ci-qa-actionlint.yml` steps `env-validation` ～ `lint-execute`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When 各ステップの `if` 条件を検査する
+  - Expected: 各 `if` 式が `steps.<prev>.outcome == 'success'` パターンのみ
+  - `yq: yq '.jobs.qa-actionlint.steps[] | select(.id != "target-checkout" and .id != "report-upload") | {(.id): .if}' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-02-03-02**: `tool-install`、`config-checkout`、`prepare-report`、`lint-execute` のいずれにも `continue-on-error: true` がないこと
+  - Target: `ci-qa-actionlint.yml` steps
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When 各ステップの `continue-on-error` を検査する
+  - Expected: 対象ステップ全てで `continue-on-error` が存在しないか `false`
+  - `yq: yq '.jobs.qa-actionlint.steps[] | select(.id == "tool-install" or .id == "config-checkout" or .id == "prepare-report" or .id == "lint-execute") | .continue-on-error' .github/workflows/ci-qa-actionlint.yml`
+
+---
+
+## T-03: Failure Propagation
+
+### [異常] Error Cases
+
+#### T-03-01: Upstream failures block all downstream steps via chained gates
+
+- [x] **T-03-01-01**: 全下流 `if` 式が完全な failure-propagation チェーンを形成すること
+  - Target: `ci-qa-actionlint.yml` steps `env-validation` ～ `lint-execute`
+  - Scenario: Given 上流ステップが失敗する、When 下流ステップの評価を検査する
+  - Expected: 各ステップが直前の outcome gate を持ち、失敗時に以降のステップがすべてスキップされる
+  - `yq: yq '.jobs.qa-actionlint.steps[] | {(.id): .if}' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-03-01-02**: `config-checkout` に `continue-on-error` がなく、アクセス不能な config-repo でジョブが失敗すること
+  - Target: `ci-qa-actionlint.yml` step `config-checkout`
+  - Scenario: Given `aglabo/.github` にアクセスできない、When `config-checkout` を実行する
+  - Expected: `continue-on-error` が存在せず、ステップ失敗がジョブ全体の失敗につながる
+  - `yq: yq '.jobs.qa-actionlint.steps[] | select(.id == "config-checkout") | .continue-on-error' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-03-01-03**: lint コマンドが config-file パスを使用し、設定ファイルが存在しない場合に即時失敗すること
+  - Target: `ci-qa-actionlint.yml` step `lint-execute` の `run` コマンド
+  - Scenario: Given `config-file` が存在しないパスを指す、When `lint-execute` を実行する
+  - Expected: `run` コマンドに `${{ inputs.config-file }}` が含まれ、`exit ${PIPESTATUS[0]}` で失敗を伝播する
+  - `yq: yq '.jobs.qa-actionlint.steps[] | select(.id == "lint-execute") | .run' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-03-01-04**: `env-validation` に `continue-on-error` がないこと
+  - Target: `ci-qa-actionlint.yml` step `env-validation`
+  - Scenario: Given 環境検証が失敗する、When `env-validation` の抑制設定を検査する
+  - Expected: `continue-on-error` が存在しないか `false`
+  - `yq: yq '.jobs.qa-actionlint.steps[] | select(.id == "env-validation") | .continue-on-error' .github/workflows/ci-qa-actionlint.yml`
+
+### [エッジケース] Edge Cases
+
+#### T-03-02: Edge inputs and output suppression
+
+- [x] **T-03-02-01**: `actionlint-version` のデフォルトが `"1.7.12"` であること
+  - Target: `ci-qa-actionlint.yml` `.on.workflow_call.inputs.actionlint-version.default`
+  - Scenario: Given inputs を省略して呼び出す、When デフォルト値を検査する
+  - Expected: `default == "1.7.12"`
+  - `yq: yq '.on.workflow_call.inputs.actionlint-version.default' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-03-02-02**: `config-file` のデフォルトが `"./shared/configs/actionlint.yaml"` であること
+  - Target: `ci-qa-actionlint.yml` `.on.workflow_call.inputs.config-file.default`
+  - Scenario: Given inputs を省略して呼び出す、When デフォルト値を検査する
+  - Expected: `default == "./shared/configs/actionlint.yaml"`
+  - `yq: yq '.on.workflow_call.inputs.config-file.default' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-03-02-03**: workflow および job レベルで outputs が存在しないこと
+  - Target: `ci-qa-actionlint.yml` `.on.workflow_call.outputs` および `.jobs.qa-actionlint.outputs`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When outputs を検査する
+  - Expected: 両方とも null または未定義
+  - `yq: yq '{wf_outputs: .on.workflow_call.outputs, job_outputs: .jobs.qa-actionlint.outputs}' .github/workflows/ci-qa-actionlint.yml`
+
+---
+
+## T-04: YAML Static Validation
+
+### [正常] Normal Cases
+
+#### T-04-01: actionlint and structural invariants
+
+- [x] **T-04-01-01**: `actionlint` が `ci-qa-actionlint.yml` に対してエラーなしで終了すること
+  - Target: `ci-qa-actionlint.yml` 全体
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When actionlint で検証する
+  - Expected: `actionlint` の exit code が 0
+  - `run: actionlint -config-file ./configs/actionlint.yaml .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-04-01-02**: workflow が正確に 1 つの job `qa-actionlint` を持ち、必須ステップ ID を全て含むこと
+  - Target: `ci-qa-actionlint.yml` `.jobs`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When job と step 構造を検査する
+  - Expected: job が `qa-actionlint` のみ、step IDs に `target-checkout`、`env-validation`、`tool-install`、`config-checkout`、`prepare-report`、`lint-execute`、`report-upload` が全て含まれる
+  - `yq: yq '.jobs | keys' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-04-01-03**: 全ステップ ID が一意であること
+  - Target: `ci-qa-actionlint.yml` `.jobs.qa-actionlint.steps[].id`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When ステップ ID を検査する
+  - Expected: 重複する ID が存在しない
+  - `yq: yq '.jobs.qa-actionlint.steps[].id' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-04-01-04**: job が `ubuntu-slim` 上で動作すること
+  - Target: `ci-qa-actionlint.yml` `.jobs.qa-actionlint.runs-on`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When runner を検査する
+  - Expected: `runs-on == 'ubuntu-slim'`
+  - `yq: yq '.jobs.qa-actionlint.runs-on' .github/workflows/ci-qa-actionlint.yml`
+
+---
+
+## T-05: Config File and Report
+
+### [正常] Normal Cases
+
+#### T-05-01: config-checkout is fixed and config-file is caller-overridable
+
+- [x] **T-05-01-01**: `config-checkout` の `repository` が `aglabo/.github` に固定されていること（入力パラメータではない）
+  - Target: `ci-qa-actionlint.yml` step `config-checkout`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When `config-checkout` の `repository` を検査する
+  - Expected: `with.repository: aglabo/.github`（リテラル値、`${{ inputs.* }}` 参照でない）
+  - `yq: yq '.jobs.qa-actionlint.steps[] | select(.id == "config-checkout") | .with.repository' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-05-01-02**: `config-checkout` の `fetch-depth` が `1` であること
+  - Target: `ci-qa-actionlint.yml` step `config-checkout`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When `config-checkout` の `fetch-depth` を検査する
+  - Expected: `with.fetch-depth: 1`
+  - `yq: yq '.jobs.qa-actionlint.steps[] | select(.id == "config-checkout") | .with.fetch-depth' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-05-01-03**: `lint-execute` が `${{ inputs.config-file }}` を使用して設定ファイルパスを参照すること
+  - Target: `ci-qa-actionlint.yml` step `lint-execute`
+  - Scenario: Given `config-file` 入力が指定された状態で呼び出す、When `lint-execute` の `run` を検査する
+  - Expected: `run` に `${{ inputs.config-file }}` が含まれる
+  - `yq: yq '.jobs.qa-actionlint.steps[] | select(.id == "lint-execute") | .run' .github/workflows/ci-qa-actionlint.yml`
+
+#### T-05-02: Report preparation and lint output
+
+- [x] **T-05-02-01**: `prepare-report` が `mkdir -p .github/report` を実行し、`if: steps.config-checkout.outcome == 'success'` でゲートされること
+  - Target: `ci-qa-actionlint.yml` step `prepare-report`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When `prepare-report` ステップを検査する
+  - Expected: `run: mkdir -p .github/report`、`if: steps.config-checkout.outcome == 'success'`
+  - `yq: yq '.jobs.qa-actionlint.steps[] | select(.id == "prepare-report")' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-05-02-02**: `lint-execute` の `run` が `tee .github/report/actionlint-report.txt` を含むこと
+  - Target: `ci-qa-actionlint.yml` step `lint-execute`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When `lint-execute` の出力先を検査する
+  - Expected: `run` に `tee .github/report/actionlint-report.txt` が含まれる
+  - `yq: yq '.jobs.qa-actionlint.steps[] | select(.id == "lint-execute") | .run' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-05-02-03**: `lint-execute` の `run` が `exit ${PIPESTATUS[0]}` で終了コードを伝播すること
+  - Target: `ci-qa-actionlint.yml` step `lint-execute`
+  - Scenario: Given actionlint がエラーを検出する、When `lint-execute` を実行する
+  - Expected: `run` に `exit ${PIPESTATUS[0]}` が含まれ、非ゼロ終了コードが伝播される
+  - `yq: yq '.jobs.qa-actionlint.steps[] | select(.id == "lint-execute") | .run' .github/workflows/ci-qa-actionlint.yml`
+
+### [異常] Error Cases
+
+#### T-05-03: Report upload on failure
+
+- [x] **T-05-03-01**: `report-upload` が `if: failure() && steps.lint-execute.outcome == 'failure'` で存在すること
+  - Target: `ci-qa-actionlint.yml` step `report-upload`
+  - Scenario: Given `lint-execute` が失敗する、When `report-upload` の条件を検査する
+  - Expected: `if: failure() && steps.lint-execute.outcome == 'failure'`
+  - `yq: yq '.jobs.qa-actionlint.steps[] | select(.id == "report-upload") | .if' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-05-03-02**: `report-upload` が `name: actionlint-report`、`path: .github/report/actionlint-report.txt`、`retention-days: 30` を持つこと
+  - Target: `ci-qa-actionlint.yml` step `report-upload`
+  - Scenario: Given `lint-execute` が失敗する、When `report-upload` の with を検査する
+  - Expected: `with.name: actionlint-report`、`with.path: .github/report/actionlint-report.txt`、`with.retention-days: 30`
+  - `yq: yq '.jobs.qa-actionlint.steps[] | select(.id == "report-upload") | .with' .github/workflows/ci-qa-actionlint.yml`
+
+### [エッジケース] Edge Cases
+
+#### T-05-04: config-checkout persist-credentials and upload-report on success suppression
+
+- [x] **T-05-04-01**: `config-checkout` の `persist-credentials` が `false` であること
+  - Target: `ci-qa-actionlint.yml` step `config-checkout`
+  - Scenario: Given `ci-qa-actionlint.yml` が存在する、When `config-checkout` の認証情報設定を検査する
+  - Expected: `with.persist-credentials: false`
+  - `yq: yq '.jobs.qa-actionlint.steps[] | select(.id == "config-checkout") | .with.persist-credentials' .github/workflows/ci-qa-actionlint.yml`
+
+- [x] **T-05-04-02**: lint 成功時（exit code 0）に `report-upload` がスキップされること
+  - Target: `ci-qa-actionlint.yml` step `report-upload` の `if` 条件
+  - Scenario: Given `lint-execute` が exit code 0 で成功する、When `report-upload` の条件を評価する
+  - Expected: `if` 条件が `failure()` を含むため、成功時は `report-upload` が実行されない
+  - `yq: yq '.jobs.qa-actionlint.steps[] | select(.id == "report-upload") | .if' .github/workflows/ci-qa-actionlint.yml`


### PR DESCRIPTION
## Overview

**Summary**
Extracts actionlint execution into a reusable workflow and switches the QA workflow to reference it locally.

**Background / Motivation**
The actionlint job in `ci-workflows-qa.yml` was a standalone job. Extracting it into a `workflow_call`-based reusable workflow allows other repositories to reuse the same actionlint checks, and makes the version and config path configurable via input parameters.

## Changes

### Core Changes

- `.github/workflows/ci-qa-actionlint.yml` (new): Reusable workflow triggered by `workflow_call`. Accepts `actionlint-version` and `config-file` as inputs. Runs 7 steps with `outcome`-based guards: checkout, environment validation, tool install, config fetch, lint, and artifact upload on failure.
- `.github/workflows/ci-workflows-qa.yml`: Switches the `actionlint` job `uses` reference from an external repo to the local workflow (`./.github/workflows/ci-qa-actionlint.yml`).

### Test Updates

- `docs/.deckrd/reusable-workflows/actionlint/tasks/tasks.md`: Completed task checklist with 44 test cases across 5 test targets. All items marked done.

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Configuration
- [x] CI/CD
- [ ] Other

## Related Issues

> Closes #71

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [x] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

Default input values for the reusable workflow:
- `actionlint-version`: `1.7.12`
- `config-file`: `./shared/configs/actionlint.yaml` (fetched from aglabo/.github)

The workflow filename was changed from `ci-scan-actionlint.yml` to `ci-qa-actionlint.yml` during design.
