### PR TITLE
ci(workflows): add local ghalint reusable workflow and fix checksum exact match

### DIFF
--- a/.github/actions/setup-tool/scripts/_libs/__tests__/unit/download.unit.spec.sh
+++ b/.github/actions/setup-tool/scripts/_libs/__tests__/unit/download.unit.spec.sh
@@ -554,6 +554,32 @@ Describe 'Given: actionlint.tar.gz does NOT exist in TEMP_DIR (only checksums.tx
   End
 End
 
+# ─── T-vfy-edg-sbom: verify_checksum() with .sbom suffix entries (bug regression) ──
+
+# shellcheck disable=SC2329
+_setup_checksum_with_sbom() {
+  _checksum_test_temp_dir=$(mktemp -d)
+  echo "fake tool content" > "${_checksum_test_temp_dir}/ghalint.tar.gz"
+  _expected_hash=$(sha256sum "${_checksum_test_temp_dir}/ghalint.tar.gz" | awk '{print $1}')
+  {
+    echo "${_expected_hash}  ghalint_1.5.6_linux_x86_64.tar.gz"
+    echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  ghalint_1.5.6_linux_x86_64.tar.gz.sbom"
+  } > "${_checksum_test_temp_dir}/checksums.txt"
+}
+
+Describe 'Given: checksums.txt contains both target entry and a .sbom suffix entry for the same base name'
+  BeforeEach '_setup_checksum_with_sbom'
+  AfterEach '_teardown_checksum'
+  Describe 'When: verify_checksum is called'
+    Describe 'Then: Task T-vfy-edg - Edge Cases (bug regression: grep-w vs grep-F)'
+      It "T-vfy-edg-03: matches only the exact filename entry and exits 0 (not tripped by .sbom line)"
+        When call verify_checksum "ghalint" "1.5.6" "x86_64" "$_checksum_test_temp_dir"
+        The status should be success
+      End
+    End
+  End
+End
+
 # ─── T-14-03: _fetch_assets() with HTTP 404 response ────────────────────────
 
 # shellcheck disable=SC2329

--- a/.github/actions/setup-tool/scripts/_libs/download.lib.sh
+++ b/.github/actions/setup-tool/scripts/_libs/download.lib.sh
@@ -126,7 +126,7 @@ verify_checksum() {
   local _checksums_file="${_temp_dir}/checksums.txt"
 
   local _expected_hash
-  _expected_hash=$(grep -w "$_original_name" "$_checksums_file" | awk '{print $1}')
+  _expected_hash=$(awk -v f="${_original_name}" '$2 == f {print $1}' "$_checksums_file")
   if [ -z "$_expected_hash" ]; then
     echo "::error::No checksum entry found for ${_original_name}" >&2
     return 3

--- a/.github/workflows/ci-qa-ghalint.yml
+++ b/.github/workflows/ci-qa-ghalint.yml
@@ -1,0 +1,86 @@
+# src: ./.github/workflows/ci-qa-ghalint.yml
+# @(#) : Reusable workflow for GitHub Actions workflow linting with ghalint
+#
+# Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+name: "CI QA Ghalint"
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      ghalint-version:
+        description: "Version of ghalint to install"
+        required: false
+        default: "1.5.6"
+        type: string
+      config-file:
+        description: "Path to the ghalint configuration file"
+        required: false
+        default: "./shared/configs/ghalint.yaml"
+        type: string
+
+jobs:
+  qa-ghalint:
+    name: Ghalint Workflow QA
+    runs-on: ubuntu-slim
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout target repository
+        id: target-checkout
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Validate environment
+        id: env-validation
+        if: steps.target-checkout.outcome == 'success'
+        uses: ./.github/actions/validate-environment
+        with:
+          actions-type: read
+
+      - name: Install ghalint
+        id: tool-install
+        if: steps.env-validation.outcome == 'success'
+        uses: ./.github/actions/setup-tool
+        with:
+          repo: suzuki-shunsuke/ghalint
+          tool-version: ${{ inputs.ghalint-version }}
+
+      - name: Checkout ghalint config
+        id: config-checkout
+        if: steps.tool-install.outcome == 'success'
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          repository: aglabo/.github
+          path: shared
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Prepare report directory
+        id: prepare-report
+        if: steps.config-checkout.outcome == 'success'
+        run: mkdir -p .github/report
+
+      - name: Run ghalint
+        id: lint-execute
+        if: steps.prepare-report.outcome == 'success'
+        run: |
+          ghalint run --config "${{ inputs.config-file }}" 2>&1 | tee .github/report/ghalint-report.txt
+          exit "${PIPESTATUS[0]}"
+
+      - name: Upload ghalint report
+        id: report-upload
+        if: failure() && steps.lint-execute.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ghalint-report
+          path: .github/report/ghalint-report.txt
+          retention-days: 30

--- a/.github/workflows/ci-workflows-qa.yml
+++ b/.github/workflows/ci-workflows-qa.yml
@@ -38,4 +38,4 @@ jobs:
     name: Ghalint
     permissions:
       contents: read
-    uses: aglabo/.github/.github/workflows/ci-common-lint-ghalint.yml@38070c03acff350b4c8f46d684781052b70c0e58 # r1.1.2
+    uses: ./.github/workflows/ci-qa-ghalint.yml

--- a/docs/.deckrd/reusable-workflows/ghalint/implementation/implementation.md
+++ b/docs/.deckrd/reusable-workflows/ghalint/implementation/implementation.md
@@ -1,0 +1,74 @@
+---
+title: "Implementation Plan: Ghalint Reusable Workflow"
+based-on: specifications.md v1.0.0
+status: Draft
+---
+
+<!-- markdownlint-disable line-length -->
+
+## 1. Overview
+
+### 1.1 Purpose
+
+`ci-qa-ghalint.yml` reusable workflow を新規作成し、`ci-workflows-qa.yml` における
+外部リポジトリ (`aglabo/.github`) への ghalint 依存をローカル呼び出しに置き換える。
+
+実装は `ci-qa-actionlint.yml` と同じ 7 ステップパターンに完全に準拠する:
+target-checkout → env-validation → tool-install → config-checkout →
+prepare-report → lint-execute → report-upload。
+
+### 1.2 Reference
+
+- Prior Art: `docs/.deckrd/reusable-workflows/actionlint/implementation/implementation.md`（直接テンプレート）
+- Specifications: `docs/.deckrd/reusable-workflows/ghalint/specifications/specifications.md`
+- Pattern reference: `.github/workflows/ci-qa-actionlint.yml`
+
+### 1.3 Open Questions (解決必要)
+
+以下は実装前に確認が必要な未解決事項:
+
+- ghalint のデフォルトバージョン番号: `1.5.6`（最新安定版、2026-06-13 確認済み）
+- `aglabo/.github` リポジトリに `shared/configs/ghalint.yaml` が存在するか
+
+---
+
+## 2. Implementation Plan
+
+### Phase 1: Ghalint Reusable Workflow 作成
+
+#### Commit 1: `ci(workflows/ci-qa-ghalint): add reusable ghalint workflow`
+
+- `.github/workflows/ci-qa-ghalint.yml` を新規作成する
+- `on.workflow_call` トリガーを定義し、以下の inputs を設定する:
+  -- `ghalint-version`: string, required: false, default: `<最新安定版>` (Open Question)
+  -- `config-file`: string, required: false, default: `./shared/configs/ghalint.yaml`
+- `permissions: contents: read` を workflow レベルで設定する
+- `jobs.qa-ghalint` を定義する:
+  -- `runs-on: ubuntu-slim`
+  -- `timeout-minutes: 10`
+  -- `permissions: contents: read`（job レベルでも明示）
+- Step 1 `target-checkout`: `actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3` で `persist-credentials: false`
+- Step 2 `env-validation`: `./.github/actions/validate-environment` で `actions-type: read`、条件: `steps.target-checkout.outcome == 'success'`
+- Step 3 `tool-install`: `./.github/actions/setup-tool` で `repo: suzuki-shunsuke/ghalint`、`tool-version: ${{ inputs.ghalint-version }}`、条件: `steps.env-validation.outcome == 'success'`
+- Step 4 `config-checkout`: `actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3` で `repository: aglabo/.github`、`path: shared`、`fetch-depth: 1`、`persist-credentials: false`、条件: `steps.tool-install.outcome == 'success'`
+- Step 5 `prepare-report`: `run: mkdir -p .github/report`、条件: `steps.config-checkout.outcome == 'success'`
+- Step 6 `lint-execute`: `run: ghalint run --config "${{ inputs.config-file }}" 2>&1 | tee .github/report/ghalint-report.txt; exit "${PIPESTATUS[0]}"`、条件: `steps.prepare-report.outcome == 'success'`
+- Step 7 `report-upload`: `actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1`、`name: ghalint-report`、`path: .github/report/ghalint-report.txt`、`retention-days: 30`、条件: `failure() && steps.lint-execute.outcome == 'failure'`
+
+### Phase 2: CI Caller 更新
+
+#### Commit 2: `ci(workflows/ci-workflows-qa): replace external ghalint with local reusable workflow`
+
+- `.github/workflows/ci-workflows-qa.yml` の `ghalint` ジョブを編集する
+- `uses: aglabo/.github/.github/workflows/ci-common-lint-ghalint.yml@38070c03acff350b4c8f46d684781052b70c0e58` を削除する
+- `uses: ./.github/workflows/ci-qa-ghalint.yml` に置き換える
+- `with:` ブロックは不要（全デフォルト値を使用）
+- `permissions: contents: read` は維持する
+
+---
+
+## 3. Change History
+
+| Date       | Version | Description                 |
+| ---------- | ------- | --------------------------- |
+| 2026-06-13 | 1.0     | Initial implementation plan |

--- a/docs/.deckrd/reusable-workflows/ghalint/requirements/requirements.md
+++ b/docs/.deckrd/reusable-workflows/ghalint/requirements/requirements.md
@@ -1,0 +1,361 @@
+---
+title: "Requirements: Ghalint Reusable Workflow"
+module: "reusable-workflows/ghalint"
+status: Draft
+version: 1.0
+created: "2026-06-13"
+---
+
+<!-- markdownlint-disable line-length -->
+
+## 1. Overview
+
+### 1.1 Purpose
+
+本文書は、GitHub Actions ワークフローポリシー検証ツール ghalint を実行するための
+reusable workflow (`ci-qa-ghalint.yml`) を ci-platform リポジトリ内に作成し、
+`ci-workflows-qa.yml` における外部リポジトリ (`aglabo/.github`) への依存を
+ローカル reusable workflow 呼び出しに置き換えることを目的とする。
+
+### 1.2 Scope
+
+- `ci-qa-ghalint.yml`: `workflow_call` トリガーをもつ ghalint 専用 reusable workflow の作成
+- `ci-workflows-qa.yml`: 外部 ghalint workflow 呼び出しをローカル呼び出しに置き換え
+- 設定ファイルは `aglabo/.github` リポジトリから `./shared/` にチェックアウトして使用
+- 入力パラメータ: `ghalint-version`（バージョン固定）、`config-file`（設定パス指定）
+- 失敗時のみレポートをアーティファクトとしてアップロード
+
+**Out of Scope**:
+
+- ghalint の新規ポリシー追加や `configs/ghalint.yaml` の設定変更
+- ghalint 以外の QA ツール（actionlint, betterleaks）の変更
+- `workflow_dispatch` による手動トリガーのサポート
+- セルフホストランナー以外の環境サポート
+
+## 2. Context
+
+- Target Environment: GitHub Actions (ubuntu-slim セルフホストランナー)
+- Related Components: `ci-workflows-qa.yml`, `.github/actions/validate-environment`, `.github/actions/setup-tool`, `aglabo/.github`（設定リポジトリ）, `configs/ghalint.yaml`
+- Assumptions: `setup-tool` composite action が `suzuki-shunsuke/ghalint` の GitHub Releases からバイナリを取得できる
+
+### System Context Diagram
+
+```text
+[ci-workflows-qa.yml]  -->  +-----------------------------+  -->  [ghalint binary]
+                            |   ci-qa-ghalint.yml         |
+[aglabo/.github]       -->  |   (reusable workflow)       |  -->  [.github/report/]
+                            +-----------------------------+
+                                         |
+                            [configs/ghalint.yaml (shared)]
+```
+
+## 3. Design Decisions (Summary)
+
+| ID    | Decision                                                      | Linked Record            |
+| ----- | ------------------------------------------------------------- | ------------------------ |
+| DR-01 | 外部依存を排除しローカル reusable workflow として実装         | decision-record.md#DR-01 |
+| DR-02 | 設定は `aglabo/.github` からチェックアウト（actionlint 踏襲） | decision-record.md#DR-02 |
+| DR-03 | 入力パラメータは `ghalint-version` と `config-file` の 2 つ   | decision-record.md#DR-03 |
+| DR-04 | ステップ間条件は `steps.<id>.outcome == 'success'` パターン   | decision-record.md#DR-04 |
+| DR-05 | 失敗時のみレポートをアーティファクトアップロード              | decision-record.md#DR-05 |
+
+## 4. Functional Requirements
+
+### REQ-F-001: Workflow Call Trigger
+
+- EARS Type: feature-based (WHERE)
+
+```text
+GIVEN a caller workflow invokes ci-qa-ghalint.yml
+  WHERE the workflow defines on.workflow_call
+THEN the system SHALL accept the invocation and execute the ghalint job.
+```
+
+**Rationale**: CI パイプラインから呼び出されることのみをサポートし、手動トリガーは対象外とする。
+
+**Acceptance Criteria**:
+
+| AC ID  | Scenario                                 |
+| ------ | ---------------------------------------- |
+| AC-001 | caller workflow から正常に呼び出せること |
+
+### REQ-F-002: Input Parameter Resolution
+
+- EARS Type: event-driven (WHEN)
+
+```text
+GIVEN the workflow is invoked via workflow_call
+  WHEN input parameters are provided or omitted
+THEN the system SHALL resolve ghalint-version to the provided value or the default version,
+     and SHALL resolve config-file to the provided path or the default path
+     (./shared/configs/ghalint.yaml).
+```
+
+**Rationale**: バージョンと設定パスを呼び出し側から上書き可能にし、デフォルト値で運用できるようにする。
+
+**Acceptance Criteria**:
+
+| AC ID  | Scenario                                           |
+| ------ | -------------------------------------------------- |
+| AC-002 | デフォルト値でパラメータなし呼び出しが成功すること |
+| AC-003 | 明示的なバージョン指定が反映されること             |
+
+### REQ-F-003: Target Repository Checkout
+
+- EARS Type: event-driven (WHEN)
+
+```text
+GIVEN the workflow job starts
+  WHEN the job begins execution
+THEN the system SHALL checkout the target repository with persist-credentials: false.
+```
+
+**Rationale**: `persist-credentials: false` により認証情報の漏洩リスクを排除する。
+
+**Acceptance Criteria**:
+
+| AC ID  | Scenario                                     |
+| ------ | -------------------------------------------- |
+| AC-004 | チェックアウトが成功し後続ステップへ進むこと |
+
+### REQ-F-004: Environment Validation
+
+- EARS Type: event-driven (WHEN)
+
+```text
+GIVEN the target repository checkout succeeds
+  WHEN the env-validation step is reached
+THEN the system SHALL execute validate-environment composite action,
+     and SHALL block subsequent steps if validation fails.
+```
+
+**Rationale**: 実行環境が要件を満たすことを保証し、不正環境での実行を防止する。
+
+**Acceptance Criteria**:
+
+| AC ID  | Scenario                               |
+| ------ | -------------------------------------- |
+| AC-005 | 正常環境で validation が pass すること |
+
+### REQ-F-005: Tool Installation
+
+- EARS Type: event-driven (WHEN)
+
+```text
+GIVEN the environment validation succeeds
+  WHEN the tool-install step is reached
+THEN the system SHALL install ghalint binary via setup-tool composite action
+     using suzuki-shunsuke/ghalint repository and the resolved ghalint-version.
+```
+
+**Rationale**: `setup-tool` action を使うことで、他ツール（actionlint, betterleaks）と一貫したインストール方式を維持する。
+
+**Acceptance Criteria**:
+
+| AC ID  | Scenario                                          |
+| ------ | ------------------------------------------------- |
+| AC-006 | 指定バージョンの ghalint がインストールされること |
+
+### REQ-F-006: Config Repository Checkout
+
+- EARS Type: event-driven (WHEN)
+
+```text
+GIVEN the tool installation succeeds
+  WHEN the config-checkout step is reached
+THEN the system SHALL checkout aglabo/.github repository into ./shared/
+     with fetch-depth: 1 and persist-credentials: false.
+```
+
+**Rationale**: 設定を外部リポジトリ `aglabo/.github` で一元管理し、ローカルの `config-file` 入力で上書き可能にする。
+
+**Acceptance Criteria**:
+
+| AC ID  | Scenario                                         |
+| ------ | ------------------------------------------------ |
+| AC-007 | `./shared/configs/ghalint.yaml` が配置されること |
+
+### REQ-F-007: Lint Execution
+
+- EARS Type: event-driven (WHEN)
+
+```text
+GIVEN the config repository checkout succeeds
+  WHEN the lint-execute step is reached
+THEN the system SHALL execute ghalint with the resolved config-file path,
+     SHALL output results to .github/report/ghalint-report.txt,
+     and SHALL exit with a non-zero code if any policy violation is detected.
+```
+
+**Rationale**: lint 失敗を CI 失敗として明確に伝播させ、ポリシー違反を見逃さない。
+
+**Acceptance Criteria**:
+
+| AC ID  | Scenario                                     |
+| ------ | -------------------------------------------- |
+| AC-008 | ポリシー違反がない場合にジョブが成功すること |
+| AC-009 | ポリシー違反がある場合にジョブが失敗すること |
+
+### REQ-F-008: Report Upload on Failure
+
+- EARS Type: event-driven (WHEN)
+
+```text
+GIVEN the lint execution fails (non-zero exit)
+  WHEN the report-upload step is reached
+THEN the system SHALL upload .github/report/ghalint-report.txt as artifact
+     named ghalint-report with retention-days: 30.
+```
+
+**Rationale**: 失敗時のみアップロードすることで、成功時のストレージ消費を抑制し、エラー詳細を CI 外から参照可能にする。
+
+**Acceptance Criteria**:
+
+| AC ID  | Scenario                                                |
+| ------ | ------------------------------------------------------- |
+| AC-010 | lint 失敗時にアーティファクトがアップロードされること   |
+| AC-011 | lint 成功時にアーティファクトがアップロードされないこと |
+
+### REQ-F-009: Replace External Dependency in ci-workflows-qa.yml
+
+- EARS Type: event-driven (WHEN)
+
+```text
+GIVEN ci-qa-ghalint.yml is created and validated
+  WHEN ci-workflows-qa.yml is updated
+THEN the system SHALL replace the external aglabo/.github ghalint workflow call
+     with a local call to ./.github/workflows/ci-qa-ghalint.yml.
+```
+
+**Rationale**: 外部リポジトリへの依存を排除し、ghalint workflow をリポジトリ内で完結して管理する。
+
+**Acceptance Criteria**:
+
+| AC ID  | Scenario                                                 |
+| ------ | -------------------------------------------------------- |
+| AC-012 | `ci-workflows-qa.yml` がローカル workflow を呼び出すこと |
+
+## 5. Non-Functional Requirements
+
+### REQ-NF-001: Security
+
+Implementation MUST set `permissions: contents: read` at both workflow and job level.
+`persist-credentials: false` MUST be set on all checkout steps.
+
+### REQ-NF-002: Consistency
+
+The implementation SHOULD follow the same 7-step pattern as `ci-qa-actionlint.yml`
+(target-checkout → env-validation → tool-install → config-checkout → prepare-report → lint-execute → report-upload).
+
+### REQ-NF-003: Maintainability
+
+The workflow SHOULD use explicit SHA-pinned action versions for all `uses:` references.
+The `timeout-minutes: 10` MUST be set at job level.
+
+### REQ-NF-004: Traceability
+
+Step IDs MUST follow the naming convention established in `ci-qa-actionlint.yml`:
+`target-checkout`, `env-validation`, `tool-install`, `config-checkout`, `prepare-report`, `lint-execute`, `report-upload`.
+
+## 6. Constraints
+
+### REQ-C-001: Runner
+
+The job MUST run on `ubuntu-slim` (self-hosted runner).
+
+### REQ-C-002: Step Condition Pattern
+
+Step conditions MUST use `if: steps.<id>.outcome == 'success'` pattern.
+The `outputs.status != 'error'` pattern is PROHIBITED.
+
+### REQ-C-003: Workflow Trigger
+
+The workflow MUST support `workflow_call` trigger only.
+`workflow_dispatch` is out of scope.
+
+### REQ-C-004: ghalint Config Source
+
+The default configuration MUST be sourced from `aglabo/.github` repository,
+checked out into `./shared/`. The `config-file` input MAY override the path.
+
+## 7. User Stories
+
+- As a CI pipeline maintainer, I want a local ghalint reusable workflow, so that I can eliminate the external dependency on `aglabo/.github` and manage all workflow QA tools consistently within the repository.
+- As a workflow author, I want ghalint to run automatically on every CI call, so that policy violations are caught before merge.
+- As a CI pipeline maintainer, I want to specify the ghalint version as an input parameter, so that version upgrades can be applied without modifying the workflow file itself.
+- As a developer investigating a CI failure, I want the ghalint report artifact to be available on failure, so that I can review policy violations without re-running the job.
+- As a repository administrator, I want `ci-workflows-qa.yml` to use only local workflow references, so that all CI dependencies are version-controlled within this repository.
+
+## 8. Acceptance Criteria
+
+```gherkin
+# AC-001: Normal invocation from caller workflow
+# Requirement: REQ-F-001
+Scenario: Normal invocation from caller workflow
+  Given ci-workflows-qa.yml calls ci-qa-ghalint.yml via workflow_call
+  When  the ghalint job executes
+  Then  all 7 steps complete in sequence without error
+
+# AC-008: Lint passes when no policy violations exist
+# Requirement: REQ-F-007
+Scenario: Lint passes when no policy violations exist
+  Given all workflow files conform to ghalint policies
+  When  ghalint executes with the resolved config-file
+  Then  ghalint exits with code 0 and the job succeeds
+
+# AC-009: Lint fails when policy violations exist
+# Requirement: REQ-F-007
+Scenario: Lint fails when policy violations exist
+  Given at least one workflow file violates a ghalint policy
+  When  ghalint executes with the resolved config-file
+  Then  ghalint exits with a non-zero code and the job fails
+
+# AC-010: Report artifact uploaded on failure
+# Requirement: REQ-F-008
+Scenario: Report artifact uploaded on failure
+  Given the lint-execute step exits with a non-zero code
+  When  the report-upload step evaluates its condition
+  Then  ghalint-report.txt is uploaded as artifact ghalint-report with 30-day retention
+
+# AC-011: Report artifact not uploaded on success
+# Requirement: REQ-F-008
+Scenario: Report artifact not uploaded on success
+  Given the lint-execute step exits with code 0
+  When  the report-upload step evaluates its condition
+  Then  no artifact is uploaded
+```
+
+## 9. Traceability
+
+| REQ ID     | AC IDs         | Type           |
+| ---------- | -------------- | -------------- |
+| REQ-F-001  | AC-001         | Functional     |
+| REQ-F-002  | AC-002, AC-003 | Functional     |
+| REQ-F-003  | AC-004         | Functional     |
+| REQ-F-004  | AC-005         | Functional     |
+| REQ-F-005  | AC-006         | Functional     |
+| REQ-F-006  | AC-007         | Functional     |
+| REQ-F-007  | AC-008, AC-009 | Functional     |
+| REQ-F-008  | AC-010, AC-011 | Functional     |
+| REQ-F-009  | AC-012         | Functional     |
+| REQ-NF-001 | —              | Non-Functional |
+| REQ-NF-002 | —              | Non-Functional |
+| REQ-NF-003 | —              | Non-Functional |
+| REQ-NF-004 | —              | Non-Functional |
+| REQ-C-001  | —              | Constraint     |
+| REQ-C-002  | —              | Constraint     |
+| REQ-C-003  | —              | Constraint     |
+| REQ-C-004  | —              | Constraint     |
+
+## 10. Open Questions
+
+| Question                                                                           | Type    | Impact Area         | Owner |
+| ---------------------------------------------------------------------------------- | ------- | ------------------- | ----- |
+| ghalint のデフォルトバージョン番号（`suzuki-shunsuke/ghalint` 最新安定版）は何か？ | Version | REQ-F-005           | TBD   |
+| `aglabo/.github` の `shared/configs/ghalint.yaml` が存在するか確認が必要           | Config  | REQ-F-006, REQ-C-04 | TBD   |
+
+## 11. Change History
+
+| Date       | Version | Description     |
+| ---------- | ------- | --------------- |
+| 2026-06-13 | 1.0.0   | Initial release |

--- a/docs/.deckrd/reusable-workflows/ghalint/specifications/specifications.md
+++ b/docs/.deckrd/reusable-workflows/ghalint/specifications/specifications.md
@@ -1,0 +1,302 @@
+---
+title: "Design Specification: Ghalint Reusable Workflow"
+based-on: requirements.md v1.0
+status: Draft
+version: 1.0.0
+created: "2026-06-13"
+---
+
+<!-- markdownlint-disable line-length -->
+
+## 1. Overview
+
+### 1.1 Purpose
+
+本文書は、`ci-qa-ghalint.yml` reusable workflow の振る舞い仕様を定義する。
+ghalint によるワークフローポリシー検証を 7 ステップのシーケンシャル実行として記述し、
+`ci-workflows-qa.yml` における外部依存の置き換え動作を含む。
+
+### 1.2 Scope
+
+本仕様は `ci-qa-ghalint.yml` の**振る舞いルールと分類セマンティクス**を定義する。
+実装の詳細（YAML フィールドの具体的な値、アクションバージョンの SHA 等）は明示的にスコープ外とする。
+
+---
+
+## 2. Design Principles
+
+### 2.1 Classification Philosophy
+
+各実行ステップは前のステップの成功を前提条件とする。
+いずれかのステップが失敗した場合、後続のステップはすべてブロックされる。
+ただし、report-upload ステップは lint-execute の失敗時のみ実行される例外的な後処理である。
+
+### 2.2 Design Assumptions
+
+- 実行環境は Linux ベースのセルフホストランナーである
+- `setup-tool` composite action は指定リポジトリの GitHub Releases からバイナリを取得できる
+- `validate-environment` composite action は `actions-type: read` で正常に動作する
+- `aglabo/.github` リポジトリは `workflow_call` 実行時にアクセス可能である
+
+### 2.3 External Design Summary
+
+> **Source**: Derived from the external design dialogue (Phase E) and user-confirmed design direction (Phase D).
+
+#### Feature Decomposition
+
+| Unit            | Responsibility                                              | REQ Coverage               |
+| --------------- | ----------------------------------------------------------- | -------------------------- |
+| trigger-inputs  | 呼び出し側入力とデフォルト値を解決する                      | REQ-F-001, REQ-F-002       |
+| target-checkout | ターゲットリポジトリをワークスペースに配置する              | REQ-F-003                  |
+| env-validation  | ランナー環境と権限を検証する                                | REQ-F-004                  |
+| tool-install    | ghalint バイナリを実行パスにインストールする                | REQ-F-005                  |
+| config-checkout | 共有設定リポジトリを取得してワークスペースに配置する        | REQ-F-006                  |
+| prepare-report  | レポート出力先ディレクトリを準備する                        | REQ-F-007                  |
+| lint-execute    | ghalint を実行しポリシー違反を検出する                      | REQ-F-007                  |
+| report-upload   | 失敗時のみレポートをアーティファクトとして保存する          | REQ-F-008                  |
+| caller-update   | 外部依存をローカル呼び出しに置き換える                      | REQ-F-009                  |
+
+#### Unit Interaction Map
+
+```text
+[workflow_call] --> +----------------+
+                    | trigger-inputs |
+                    +----------------+
+                           |
+                           v
+                    +----------------+
+                    | target-checkout|
+                    +----------------+
+                           |
+                           v
+                    +----------------+
+                    | env-validation |
+                    +----------------+
+                           |
+                           v
+                    +----------------+
+                    |  tool-install  | <-- [suzuki-shunsuke/ghalint Releases]
+                    +----------------+
+                           |
+                           v
+                    +----------------+
+                    | config-checkout| <-- [aglabo/.github repository]
+                    +----------------+
+                           |
+                           v
+                    +----------------+
+                    | prepare-report |
+                    +----------------+
+                           |
+                           v
+                    +----------------+
+                    |  lint-execute  | --> [.github/report/ghalint-report.txt]
+                    +----------------+
+                     (failure only) |
+                           v
+                    +----------------+
+                    | report-upload  | --> [artifact: ghalint-report]
+                    +----------------+
+```
+
+#### Data Flow Diagram
+
+```text
+[inputs]             --> [trigger-inputs] --> [resolved-version, resolved-config-path]
+[target-repo]        --> [target-checkout] --> [workspace/source]
+[workspace/source]   --> [env-validation]  --> [env-status]
+[ghalint-releases]   --> [tool-install]    --> [ghalint-binary-in-PATH]
+[aglabo/.github]     --> [config-checkout] --> [./shared/configs/ghalint.yaml]
+[ghalint-binary]     --> [lint-execute]    --> [ghalint-report.txt, exit-code]
+[exit-code: failure] --> [report-upload]   --> [artifact: ghalint-report]
+```
+
+### 2.4 Non-Goals
+
+> **Derivation**: All items below originate from REQUIREMENTS Section "Out of Scope".
+
+- ghalint ポリシーの追加・変更 ← REQ: Out of Scope
+- ghalint 以外の QA ツール（actionlint, betterleaks）の変更 ← REQ: Out of Scope
+- `workflow_dispatch` による手動トリガーのサポート ← REQ: Out of Scope
+- セルフホストランナー以外の環境サポート ← REQ: Out of Scope
+
+### 2.5 Behavioral Design Decisions
+
+| ID    | Decision                                                             | Rationale                                                              | Affected Rules          | Status |
+| ----- | -------------------------------------------------------------------- | ---------------------------------------------------------------------- | ----------------------- | ------ |
+| DD-01 | 外部依存を排除しローカル reusable workflow として実装               | 外部リポジトリの可用性リスクを排除し、バージョン管理を一元化する       | R-001〜R-009            | Active |
+| DD-02 | 設定は `aglabo/.github` からチェックアウト（actionlint パターン踏襲） | 設定の一元管理と `config-file` 入力による上書き可能性を両立する        | R-006, R-007            | Active |
+| DD-03 | 入力パラメータは `ghalint-version` と `config-file` の 2 つ         | 呼び出し側がバージョンと設定パスを制御できる最小限のインターフェース   | R-002                   | Active |
+| DD-04 | ステップ間条件は `steps.<id>.outcome == 'success'` パターン         | プロジェクト既存ワークフロー（actionlint）との一貫性を維持する         | R-001〜R-008            | Active |
+| DD-05 | 失敗時のみレポートをアーティファクトアップロード                    | 成功時のストレージ消費を抑制し、エラー確認の利便性を確保する           | R-009                   | Active |
+
+### 2.6 Related Decision Records
+
+> **Reference**: requirements.md に DR-01〜DR-05 として記載。`decision-records.md` は未作成。
+
+> "No Decision Records currently affect this specification. DR candidates are listed in Section 2.5."
+
+### 2.7 DD to DR Promotion Criteria
+
+DD-01（外部依存排除）と DD-02（設定リポジトリ固定）は、他の reusable workflow モジュール（actionlint, betterleaks）にも共通する設計判断であるため、将来的に DR へ昇格させることを検討する。
+
+---
+
+## 3. Behavioral Specification
+
+### 3.1 Input Domain
+
+- `ghalint-version`: バージョン文字列（X.Y.Z 形式）。省略時はデフォルト値を使用する。
+- `config-file`: 設定ファイルのパス文字列。省略時は `./shared/configs/ghalint.yaml` を使用する。
+- トリガー: `workflow_call` のみ。他のトリガーは受け付けない。
+
+### 3.2 Output Semantics
+
+- exit code 0: 全ステップが成功し、ポリシー違反が検出されなかった
+- exit code 非ゼロ: ポリシー違反が検出されたか、いずれかのステップが失敗した
+- 副作用:
+  - `.github/report/ghalint-report.txt`: lint 実行結果を常に出力する（lint-execute 到達時）
+  - `ghalint-report` アーティファクト: lint-execute 失敗時のみ 30 日間保持する
+
+### 3.3 Unit Behavioral Contracts
+
+#### trigger-inputs
+
+- `ghalint-version` が指定された場合、その値をそのまま使用する
+- `ghalint-version` が省略された場合、事前定義されたデフォルトバージョンを使用する
+- `config-file` が指定された場合、その値をそのまま使用する
+- `config-file` が省略された場合、`./shared/configs/ghalint.yaml` を使用する
+- この処理は失敗しない（入力省略はデフォルト値で補完される）
+
+#### target-checkout
+
+- 認証情報がワークスペースに残留しないよう保護した状態でチェックアウトする
+- チェックアウト失敗時、後続の全ステップをブロックする
+
+#### env-validation
+
+- target-checkout が成功した場合のみ実行する
+- 読み取り権限のみを要求する環境検証を実行する
+- 検証失敗時、tool-install 以降の全ステップをブロックする
+
+#### tool-install
+
+- env-validation が成功した場合のみ実行する
+- `suzuki-shunsuke/ghalint` リポジトリの解決済みバージョンをインストールする
+- インストール後、ghalint バイナリは実行パスから呼び出し可能な状態になる
+- インストール失敗時、config-checkout 以降の全ステップをブロックする
+
+#### config-checkout
+
+- tool-install が成功した場合のみ実行する
+- `aglabo/.github` リポジトリを浅いチェックアウト（履歴 1 件）で取得する
+- 認証情報がワークスペースに残留しないよう保護した状態でチェックアウトする
+- チェックアウト後、`./shared/` 配下に設定ファイルが配置された状態になる
+- チェックアウト失敗時、prepare-report 以降の全ステップをブロックする
+
+#### prepare-report
+
+- config-checkout が成功した場合のみ実行する
+- レポート出力先ディレクトリが存在しない場合は作成する
+- ディレクトリが既に存在する場合も失敗しない（冪等）
+- 準備失敗時、lint-execute をブロックする
+
+#### lint-execute
+
+- prepare-report が成功した場合のみ実行する
+- 解決済みの設定ファイルパスを使用して ghalint を実行する
+- 実行結果をレポートファイルに出力する
+- ポリシー違反が検出された場合、非ゼロ終了コードを伝播してジョブを失敗させる
+- ポリシー違反がない場合、ゼロ終了コードでジョブを成功させる
+
+#### report-upload
+
+- lint-execute が失敗した場合のみ実行する（成功時は実行しない）
+- lint-execute のレポートファイルをアーティファクトとして保存する
+- アーティファクトの保持期間は 30 日間とする
+- このステップ自体の失敗は非致命的（既にジョブは失敗状態）
+
+---
+
+## 4. Decision Rules
+
+Evaluation MUST follow this order:
+
+| Rule ID | Step | Condition                                              | Outcome                                          |
+| ------- | ---: | ------------------------------------------------------ | ------------------------------------------------ |
+| R-001   |    1 | workflow_call で呼び出された                           | trigger-inputs を実行し入力値を解決する          |
+| R-002   |    2 | ghalint-version が指定された                           | 指定バージョンを使用する                         |
+| R-002a  |    2 | ghalint-version が省略された                           | デフォルトバージョンを使用する                   |
+| R-003   |    3 | config-file が指定された                               | 指定パスを使用する                               |
+| R-003a  |    3 | config-file が省略された                               | `./shared/configs/ghalint.yaml` を使用する       |
+| R-004   |    4 | target-checkout が成功した                             | env-validation を実行する                        |
+| R-004a  |    4 | target-checkout が失敗した                             | 後続全ステップをブロックしジョブを失敗させる     |
+| R-005   |    5 | env-validation が成功した                              | tool-install を実行する                          |
+| R-005a  |    5 | env-validation が失敗した                              | tool-install 以降をブロックしジョブを失敗させる  |
+| R-006   |    6 | tool-install が成功した                                | config-checkout を実行する                       |
+| R-006a  |    6 | tool-install が失敗した                                | config-checkout 以降をブロックしジョブを失敗させる |
+| R-007   |    7 | config-checkout が成功した                             | prepare-report を実行する                        |
+| R-007a  |    7 | config-checkout が失敗した                             | prepare-report 以降をブロックしジョブを失敗させる |
+| R-008   |    8 | prepare-report が成功した                              | lint-execute を実行する                          |
+| R-008a  |    8 | prepare-report が失敗した                              | lint-execute をブロックしジョブを失敗させる      |
+| R-009   |    9 | lint-execute が成功した（exit code 0）                 | ジョブを成功させる。アーティファクトを保存しない |
+| R-009a  |    9 | lint-execute が失敗した（exit code 非ゼロ）            | report-upload を実行してアーティファクトを保存する |
+
+No reordering is permitted.
+
+---
+
+## 5. Edge Cases
+
+| Scenario                                               | 振る舞い                                        | REQ           | Rationale                                      |
+| ------------------------------------------------------ | ----------------------------------------------- | ------------- | ---------------------------------------------- |
+| `config-file` に存在しないパスを指定                   | lint-execute が失敗し report-upload が実行される | REQ-F-007     | ghalint は設定ファイル不在時に非ゼロ終了する   |
+| `ghalint-version` に存在しないバージョンを指定         | tool-install が失敗し後続がブロックされる        | REQ-F-005     | setup-tool は Releases に存在しない版を取得できない |
+| `aglabo/.github` に `shared/configs/ghalint.yaml` が不在 | lint-execute が失敗し report-upload が実行される | REQ-F-006     | Open Question — 存在確認が必要                 |
+| `.github/report/` が既に存在する状態で再実行           | prepare-report が正常終了し lint-execute へ進む  | REQ-F-007     | ディレクトリ作成は冪等                         |
+| ポリシー違反がゼロ件                                   | lint-execute が exit code 0 で終了しジョブ成功   | REQ-F-007     | 正常系                                         |
+| ポリシー違反が 1 件以上                                | lint-execute が非ゼロで終了しジョブ失敗          | REQ-F-007     | 違反を CI 失敗として確実に伝播させる           |
+| report-upload 自体が失敗                               | ジョブはすでに失敗状態であり追加エラーは記録される | REQ-F-008   | 非致命的な後処理                               |
+
+---
+
+## 6. Requirements Traceability
+
+| Requirement ID | Spec Rule            | Notes                                             |
+| -------------- | -------------------- | ------------------------------------------------- |
+| REQ-F-001      | R-001                | workflow_call トリガーのみ受け付ける              |
+| REQ-F-002      | R-002, R-002a, R-003, R-003a | 入力パラメータのデフォルト解決                  |
+| REQ-F-003      | R-004, R-004a        | target-checkout の成功/失敗分岐                  |
+| REQ-F-004      | R-005, R-005a        | env-validation の成功/失敗分岐                   |
+| REQ-F-005      | R-006, R-006a        | tool-install の成功/失敗分岐                     |
+| REQ-F-006      | R-007, R-007a        | config-checkout の成功/失敗分岐                  |
+| REQ-F-007      | R-008, R-008a, R-009 | prepare-report + lint-execute の実行と結果伝播   |
+| REQ-F-008      | R-009a               | 失敗時のみ report-upload を実行                  |
+| REQ-F-009      | DD-01                | ci-workflows-qa.yml の外部依存をローカルに置き換える（実装フェーズで扱う） |
+| REQ-NF-001     | Section 3.3 全 Unit  | 全チェックアウトで認証情報保護、最小権限を適用   |
+| REQ-NF-002     | Section 2.3          | actionlint 7 ステップパターンに準拠              |
+| REQ-NF-003     | Section 2.5 DD-04    | SHA ピン・タイムアウト設定は実装フェーズで扱う   |
+| REQ-NF-004     | Section 2.3 Unit 名  | ステップ ID 命名規則は actionlint と統一          |
+| REQ-C-001      | Section 2.2          | ubuntu-slim ランナーを前提とする                 |
+| REQ-C-002      | Section 2.5 DD-04    | `steps.<id>.outcome == 'success'` パターンのみ   |
+| REQ-C-003      | R-001                | workflow_call トリガーのみ                       |
+| REQ-C-004      | Section 3.3 config-checkout | aglabo/.github を設定ソースとして使用    |
+
+---
+
+## 7. Open Questions
+
+> **Status**: INCOMPLETE
+
+| # | Question                                                                              | Source        | Impact                                                        |
+| - | ------------------------------------------------------------------------------------- | ------------- | ------------------------------------------------------------- |
+| 1 | ghalint のデフォルトバージョン番号は何か（`suzuki-shunsuke/ghalint` 最新安定版）      | REQ-F-005     | trigger-inputs のデフォルト値が未確定                         |
+| 2 | `aglabo/.github` リポジトリに `shared/configs/ghalint.yaml` が存在するか              | REQ-F-006     | 存在しない場合、config-checkout ステップの設計変更が必要      |
+
+---
+
+## 8. Change History
+
+| Date       | Version | Description           |
+| ---------- | ------- | --------------------- |
+| 2026-06-13 | 1.0.0   | Initial specification |

--- a/docs/.deckrd/reusable-workflows/ghalint/tasks/tasks.md
+++ b/docs/.deckrd/reusable-workflows/ghalint/tasks/tasks.md
@@ -1,0 +1,223 @@
+---
+title: "Implementation Tasks: Ghalint Reusable Workflow"
+module: reusable-workflows/ghalint
+status: Active
+created: "2026-06-13 00:00:00"
+source: specifications.md
+---
+
+<!-- markdownlint-disable line-length -->
+
+## Task Summary
+
+| Test Target                  | Scenarios | Cases | Status      |
+| ---------------------------- | --------- | ----- | ----------- |
+| T-01: ci-qa-ghalint.yml      | 4         | 12    | completed   |
+| T-02: trigger-inputs         | 2         | 4     | completed   |
+| T-03: step-gating            | 3         | 8     | completed   |
+| T-04: lint-execute           | 2         | 4     | completed   |
+| T-05: ci-workflows-qa update | 2         | 3     | completed   |
+
+---
+
+## T-01: ci-qa-ghalint.yml
+
+### [正常] Normal Cases
+
+#### T-01-01: workflow_call トリガーとジョブ基本設定
+
+- [x] **T-01-01-01**: workflow_call トリガーのみが定義されている
+  - Target: `ci-qa-ghalint.yml`
+  - Scenario: Given ci-qa-ghalint.yml が作成された, When on トリガーを確認する
+  - Expected: Then `on.workflow_call` のみが存在し `workflow_dispatch` は存在しない
+
+- [x] **T-01-01-02**: ジョブが ubuntu-slim で timeout-minutes: 10 で定義されている
+  - Target: `ci-qa-ghalint.yml jobs.qa-ghalint`
+  - Scenario: Given ジョブ定義を確認する, When runs-on と timeout-minutes を検査する
+  - Expected: Then `runs-on: ubuntu-slim` かつ `timeout-minutes: 10` が設定されている
+
+- [x] **T-01-01-03**: permissions: contents: read が workflow レベルと job レベルの両方に設定されている
+  - Target: `ci-qa-ghalint.yml`
+  - Scenario: Given permissions 設定を確認する, When workflow レベルと job レベルを検査する
+  - Expected: Then 両レベルで `contents: read` のみが設定されている
+
+#### T-01-02: inputs 定義
+
+- [x] **T-01-02-01**: ghalint-version input がデフォルト値付きで定義されている
+  - Target: `ci-qa-ghalint.yml on.workflow_call.inputs`
+  - Scenario: Given inputs 定義を確認する, When ghalint-version を検査する
+  - Expected: Then type: string, required: false, デフォルト値が設定されている
+
+- [x] **T-01-02-02**: config-file input がデフォルト値 `./shared/configs/ghalint.yaml` 付きで定義されている
+  - Target: `ci-qa-ghalint.yml on.workflow_call.inputs`
+  - Scenario: Given inputs 定義を確認する, When config-file を検査する
+  - Expected: Then type: string, required: false, default: `./shared/configs/ghalint.yaml` が設定されている
+
+#### T-01-03: ステップ定義と SHA ピン
+
+- [x] **T-01-03-01**: 全 7 ステップが正しい ID で順序どおりに定義されている
+  - Target: `ci-qa-ghalint.yml jobs.qa-ghalint.steps`
+  - Scenario: Given ステップ一覧を確認する, When ステップ ID と順序を検査する
+  - Expected: Then target-checkout → env-validation → tool-install → config-checkout → prepare-report → lint-execute → report-upload の順で定義されている
+
+- [x] **T-01-03-02**: actions/checkout が SHA ピンされている
+  - Target: `ci-qa-ghalint.yml steps.target-checkout, steps.config-checkout`
+  - Scenario: Given checkout ステップを確認する, When uses の値を検査する
+  - Expected: Then `actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0` が使用されている
+
+- [x] **T-01-03-03**: actions/upload-artifact が SHA ピンされている
+  - Target: `ci-qa-ghalint.yml steps.report-upload`
+  - Scenario: Given report-upload ステップを確認する, When uses の値を検査する
+  - Expected: Then `actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` が使用されている
+
+#### T-01-04: config-checkout と lint-execute の設定
+
+- [x] **T-01-04-01**: config-checkout が aglabo/.github を ./shared/ に fetch-depth: 1 でチェックアウトする
+  - Target: `ci-qa-ghalint.yml steps.config-checkout`
+  - Scenario: Given config-checkout ステップを確認する, When with パラメータを検査する
+  - Expected: Then `repository: aglabo/.github`, `path: shared`, `fetch-depth: 1`, `persist-credentials: false` が設定されている
+
+- [x] **T-01-04-02**: lint-execute が ghalint run --config で実行され終了コードを伝播する
+  - Target: `ci-qa-ghalint.yml steps.lint-execute`
+  - Scenario: Given lint-execute ステップを確認する, When run コマンドを検査する
+  - Expected: Then `ghalint run --config "${{ inputs.config-file }}"` かつ `exit "${PIPESTATUS[0]}"` が含まれている
+
+---
+
+## T-02: trigger-inputs
+
+### [正常] Normal Cases
+
+#### T-02-01: デフォルト値の解決
+
+- [x] **T-02-01-01**: ghalint-version を省略した場合にデフォルトバージョンが使用される
+  - Target: `ci-qa-ghalint.yml inputs.ghalint-version`
+  - Scenario: Given ghalint-version を指定せず呼び出す, When tool-install が実行される
+  - Expected: Then デフォルトバージョンで ghalint がインストールされる (R-002a)
+
+- [x] **T-02-01-02**: config-file を省略した場合に `./shared/configs/ghalint.yaml` が使用される
+  - Target: `ci-qa-ghalint.yml inputs.config-file`
+  - Scenario: Given config-file を指定せず呼び出す, When lint-execute が実行される
+  - Expected: Then `./shared/configs/ghalint.yaml` が config-file として使用される (R-003a)
+
+#### T-02-02: 明示的なパラメータ指定
+
+- [x] **T-02-02-01**: 明示的に指定した ghalint-version が tool-install で使用される
+  - Target: `ci-qa-ghalint.yml inputs.ghalint-version`
+  - Scenario: Given ghalint-version を明示的に指定して呼び出す, When tool-install が実行される
+  - Expected: Then 指定したバージョンで ghalint がインストールされる (R-002)
+
+- [x] **T-02-02-02**: 明示的に指定した config-file が lint-execute で使用される
+  - Target: `ci-qa-ghalint.yml inputs.config-file`
+  - Scenario: Given config-file を明示的に指定して呼び出す, When lint-execute が実行される
+  - Expected: Then 指定したパスが `--config` 引数として使用される (R-003)
+
+---
+
+## T-03: step-gating
+
+### [正常] Normal Cases
+
+#### T-03-01: 成功時のステップ連鎖
+
+- [x] **T-03-01-01**: target-checkout 成功時に env-validation が実行される
+  - Target: `ci-qa-ghalint.yml steps.env-validation.if`
+  - Scenario: Given target-checkout が成功する, When env-validation の if 条件を確認する
+  - Expected: Then `steps.target-checkout.outcome == 'success'` 条件が設定されている (R-004)
+
+- [x] **T-03-01-02**: env-validation に actions-type: read が設定されている
+  - Target: `ci-qa-ghalint.yml steps.env-validation`
+  - Scenario: Given env-validation ステップを確認する, When with パラメータを検査する
+  - Expected: Then `actions-type: read` が設定されている
+
+- [x] **T-03-01-03**: tool-install に suzuki-shunsuke/ghalint が設定されている
+  - Target: `ci-qa-ghalint.yml steps.tool-install`
+  - Scenario: Given tool-install ステップを確認する, When with パラメータを検査する
+  - Expected: Then `repo: suzuki-shunsuke/ghalint` かつ `tool-version: ${{ inputs.ghalint-version }}` が設定されている (R-006)
+
+### [異常] Error Cases
+
+#### T-03-02: 失敗時のステップブロック
+
+- [x] **T-03-02-01**: target-checkout 失敗時に後続全ステップがブロックされる
+  - Target: `ci-qa-ghalint.yml steps.*.if`
+  - Scenario: Given target-checkout が失敗する, When 後続ステップの if 条件を確認する
+  - Expected: Then env-validation 以降の全ステップが `steps.target-checkout.outcome == 'success'` チェーンによりブロックされる (R-004a)
+
+- [x] **T-03-02-02**: report-upload は failure() かつ lint-execute 失敗時のみ実行される
+  - Target: `ci-qa-ghalint.yml steps.report-upload.if`
+  - Scenario: Given lint-execute が失敗する, When report-upload の if 条件を確認する
+  - Expected: Then `failure() && steps.lint-execute.outcome == 'failure'` が設定されている (R-009a)
+
+### [エッジケース] Edge Cases
+
+#### T-03-03: persist-credentials と認証情報保護
+
+- [x] **T-03-03-01**: target-checkout で persist-credentials: false が設定されている
+  - Target: `ci-qa-ghalint.yml steps.target-checkout`
+  - Scenario: Given target-checkout の with パラメータを確認する
+  - Expected: Then `persist-credentials: false` が設定されている (REQ-NF-001)
+
+- [x] **T-03-03-02**: config-checkout で persist-credentials: false が設定されている
+  - Target: `ci-qa-ghalint.yml steps.config-checkout`
+  - Scenario: Given config-checkout の with パラメータを確認する
+  - Expected: Then `persist-credentials: false` が設定されている (REQ-NF-001)
+
+---
+
+## T-04: lint-execute
+
+### [正常] Normal Cases
+
+#### T-04-01: ポリシー違反なし
+
+- [x] **T-04-01-01**: report-upload は lint 成功時に実行されない
+  - Target: `ci-qa-ghalint.yml steps.report-upload.if`
+  - Scenario: Given lint-execute が exit code 0 で終了する, When report-upload の条件を確認する
+  - Expected: Then `failure()` が false のためアーティファクトはアップロードされない (R-009)
+
+- [x] **T-04-01-02**: レポートファイルが正しいパスに出力される
+  - Target: `ci-qa-ghalint.yml steps.lint-execute`
+  - Scenario: Given lint-execute が実行される, When run コマンドのリダイレクトを確認する
+  - Expected: Then `.github/report/ghalint-report.txt` に tee で出力される
+
+### [異常] Error Cases
+
+#### T-04-02: ポリシー違反あり
+
+- [x] **T-04-02-01**: ポリシー違反時に report-upload が実行される
+  - Target: `ci-qa-ghalint.yml steps.report-upload`
+  - Scenario: Given lint-execute が非ゼロ終了する, When report-upload の条件を評価する
+  - Expected: Then `failure() && steps.lint-execute.outcome == 'failure'` が true となりアーティファクトがアップロードされる (R-009a)
+
+- [x] **T-04-02-02**: アーティファクトに正しい名前と保持期間が設定されている
+  - Target: `ci-qa-ghalint.yml steps.report-upload`
+  - Scenario: Given report-upload が実行される, When with パラメータを確認する
+  - Expected: Then `name: ghalint-report`, `path: .github/report/ghalint-report.txt`, `retention-days: 30` が設定されている (REQ-F-008)
+
+---
+
+## T-05: ci-workflows-qa update
+
+### [正常] Normal Cases
+
+#### T-05-01: 外部依存の置き換え
+
+- [x] **T-05-01-01**: ci-workflows-qa.yml の ghalint ジョブがローカル workflow を参照している
+  - Target: `ci-workflows-qa.yml jobs.ghalint.uses`
+  - Scenario: Given ci-workflows-qa.yml を確認する, When ghalint ジョブの uses を検査する
+  - Expected: Then `./.github/workflows/ci-qa-ghalint.yml` が使用されており外部参照は存在しない (REQ-F-009)
+
+- [x] **T-05-01-02**: 外部 aglabo/.github 参照が ci-workflows-qa.yml から削除されている
+  - Target: `ci-workflows-qa.yml`
+  - Scenario: Given ci-workflows-qa.yml の全内容を確認する
+  - Expected: Then `aglabo/.github/.github/workflows/ci-common-lint-ghalint.yml` への参照が存在しない
+
+### [エッジケース] Edge Cases
+
+#### T-05-02: permissions 維持
+
+- [x] **T-05-02-01**: ci-workflows-qa.yml の ghalint ジョブで permissions: contents: read が維持されている
+  - Target: `ci-workflows-qa.yml jobs.ghalint.permissions`
+  - Scenario: Given ghalint ジョブの permissions を確認する
+  - Expected: Then `contents: read` が設定されており他の権限は追加されていない (REQ-NF-001)


### PR DESCRIPTION
## Overview

**Summary**
Add a local ghalint reusable workflow and replace the external `aglabo/.github` dependency. Also fix a false-positive checksum mismatch caused by `.sbom` suffix entries.

**Background / Motivation**
`ci-workflows-qa.yml` called ghalint via an external reusable workflow in `aglabo/.github`. This made version management and security auditing depend on an external repository. By internalizing the workflow, all CI dependencies are now managed within this repository. The checksum bug was discovered during this work — `grep -w` incorrectly matched `.sbom`-suffixed entries in `checksums.txt`, causing spurious `Checksum mismatch` failures.

## Changes

### Core Changes

- `.github/workflows/ci-qa-ghalint.yml` — Add ghalint reusable workflow. Accepts `ghalint-version` and `config-file` inputs. Runs 7 sequential steps: target-checkout → env-validation → tool-install → config-checkout → prepare-report → lint-execute → report-upload. Uploads `ghalint-report.txt` as artifact on failure. Minimum permissions (`contents: read`).
- `.github/workflows/ci-workflows-qa.yml` — Replace external `aglabo/.github` ghalint workflow call with local `./.github/workflows/ci-qa-ghalint.yml`.
- `.github/actions/setup-tool/scripts/_libs/download.lib.sh` — Fix `verify_checksum()`: replace `grep -w ... | awk` with `awk '$2 == f'` for exact field match. Prevents `.sbom`-suffixed entries from being incorrectly matched.

### Test Updates

- `.github/actions/setup-tool/scripts/_libs/__tests__/unit/download.unit.spec.sh` — Add `T-vfy-edg-03` regression test: verify that `verify_checksum()` exits 0 when `checksums.txt` contains both a target entry and a `.sbom`-suffixed entry for the same base name.

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [x] CI/CD
- [ ] Other

## Related Issues

Closes #71

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

- `ci-qa-ghalint.yml` follows the same 7-step pattern as `ci-qa-actionlint.yml` for consistency.
- `awk '$2 == f'` selects only lines where the second whitespace-delimited field equals the target filename exactly. `grep -w` matches on word boundaries and incorrectly matches `tool-1.0.0.tar.gz.sbom` when searching for `tool-1.0.0.tar.gz`.
