### PR TITLE
ci(workflows): pin reusable workflows to exact commit hash and fix validate-environment usage

### DIFF
--- a/.github/workflows/ci-build-docs.yml
+++ b/.github/workflows/ci-build-docs.yml
@@ -37,11 +37,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Validate environment
-        uses: aglabo/ci-platform/.github/actions/validate-environment@f80bab4e9e3716456a718300a2d2445c8f7e12a1 # v0.1.1
-        with:
-          actions-type: read
-
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -107,9 +102,9 @@ jobs:
           persist-credentials: false
 
       - name: Validate environment
-        uses: aglabo/ci-platform/.github/actions/validate-environment@991f0aada325e945bab1a21ddd675fba4743ff8a # v0.1.1
+        uses: ./.github/actions/validate-environment
         with:
-          actions-type: any
+          actions-type: read
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/ci-scan-secrets.yml
+++ b/.github/workflows/ci-scan-secrets.yml
@@ -28,4 +28,4 @@ jobs:
     name: Betterleaks Secret Scan
     permissions:
       contents: read
-    uses: ./.github/workflows/ci-scan-betterleaks.yml
+    uses: aglabo/ci-platform/.github/workflows/ci-scan-betterleaks.yml@cc172e787ece39cb5d9c114f66fae3abce8e5a5a # v0.2.0

--- a/.github/workflows/ci-workflows-qa.yml
+++ b/.github/workflows/ci-workflows-qa.yml
@@ -32,10 +32,10 @@ jobs:
     name: Actionlint
     permissions:
       contents: read
-    uses: ./.github/workflows/ci-qa-actionlint.yml
+    uses: aglabo/ci-platform/.github/workflows/ci-qa-actionlint.yml@cc172e787ece39cb5d9c114f66fae3abce8e5a5a # v0.2.0
 
   ghalint:
     name: Ghalint
     permissions:
       contents: read
-    uses: ./.github/workflows/ci-qa-ghalint.yml
+    uses: aglabo/ci-platform/.github/workflows/ci-qa-ghalint.yml@cc172e787ece39cb5d9c114f66fae3abce8e5a5a # v0.2.0


### PR DESCRIPTION
## Overview

**Summary**
Pins reusable workflow references to exact commit hashes and fixes incorrect `validate-environment` usage in `ci-build-docs.yml`.

**Background / Motivation**
Local path references (`./.github/workflows/*.yml`) leave supply chain risks and make inter-workflow dependencies implicit. Pinning to full commit hashes in `aglabo/ci-platform` (v0.2.0) makes dependencies explicit and reduces security risk. Also fixes `actions-type: any` in `ci-build-docs.yml`, which should be `read`.

## Changes

### Core Changes

- **`ci-workflows-qa.yml`**: Replace local refs for `ci-qa-actionlint.yml` and `ci-qa-ghalint.yml` with pinned external refs (`aglabo/ci-platform@cc172e7`, v0.2.0)
- **`ci-scan-secrets.yml`**: Replace local ref for `ci-scan-betterleaks.yml` with pinned external ref (`aglabo/ci-platform@cc172e7`, v0.2.0)
- **`ci-build-docs.yml`**:
  - Remove unnecessary `validate-environment` step from `build` job
  - Change `validate-environment` in `deploy` job from remote hash ref to local path (`./.github/actions/validate-environment`)
  - Fix `actions-type: any` → `actions-type: read`

### Test Updates

N/A

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [x] CI/CD
- [ ] Other

## Related Issues

> Closes #76

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

Commit hash `cc172e787ece39cb5d9c114f66fae3abce8e5a5a` corresponds to `aglabo/ci-platform` v0.2.0.