### PR TITLE
fix(workflows): restore build job and revert workflow refs to local paths

### DIFF
--- a/.github/workflows/ci-build-docs.yml
+++ b/.github/workflows/ci-build-docs.yml
@@ -28,7 +28,38 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Docs
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
+
+      - name: Validate environment
+        uses: ./.github/actions/validate-environment
+        with:
+          actions-type: read
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+        with:
+          version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "22"
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "store=$(pnpm store path)" >> "$GITHUB_OUTPUT"
 
       - name: Cache pnpm store
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3

--- a/.github/workflows/ci-scan-secrets.yml
+++ b/.github/workflows/ci-scan-secrets.yml
@@ -28,4 +28,4 @@ jobs:
     name: Betterleaks Secret Scan
     permissions:
       contents: read
-    uses: aglabo/ci-platform/.github/workflows/ci-scan-betterleaks.yml@6988a3ea6c52c239c87369327d8b8318298cfd8f # v0.2.0
+    uses: ./.github/workflows/ci-scan-betterleaks.yml

--- a/.github/workflows/ci-workflows-qa.yml
+++ b/.github/workflows/ci-workflows-qa.yml
@@ -32,10 +32,10 @@ jobs:
     name: Actionlint
     permissions:
       contents: read
-    uses: aglabo/ci-platform/.github/workflows/ci-qa-actionlint.yml@6988a3ea6c52c239c87369327d8b8318298cfd8f # v0.2.0
+    uses: ./.github/workflows/ci-qa-actionlint.yml
 
   ghalint:
     name: Ghalint
     permissions:
       contents: read
-    uses: aglabo/ci-platform/.github/workflows/ci-qa-ghalint.yml@6988a3ea6c52c239c87369327d8b8318298cfd8f # v0.2.0
+    uses: ./.github/workflows/ci-qa-ghalint.yml


### PR DESCRIPTION
## Overview

**Summary**
Restores the missing `build` job in `ci-build-docs.yml` and reverts reusable workflow references back to local path format.

**Background / Motivation**
Two regressions were introduced by the merge of #79:
1. The `build` job (including all setup steps) was lost from `ci-build-docs.yml`, breaking the docs CI entirely.
2. Reusable workflow `uses:` references in `ci-scan-secrets.yml` and `ci-workflows-qa.yml` were changed to external-pinned format (`aglabo/ci-platform/...@<hash>`), which is invalid for workflows in the same repository.

## Changes

### Core Changes

- `.github/workflows/ci-build-docs.yml`: Restore the `build` job with all steps (checkout, validate-environment, pnpm, Node.js setup, cache, build, artifact upload)
- `.github/workflows/ci-scan-secrets.yml`: Change `uses:` from external-pinned ref to `./.github/workflows/ci-scan-betterleaks.yml`
- `.github/workflows/ci-workflows-qa.yml`: Change `uses:` for `actionlint` and `ghalint` jobs from external-pinned refs to local paths

### Test Updates

N/A

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [x] CI/CD
- [ ] Other

## Related Issues

> Related to #79

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

`actionlint` passes cleanly on all three modified workflow files.
