### PR TITLE
config: add .claude/settings.json with permissions and hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,46 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git diff:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git branch:*)",
+      "Bash(git remote:*)",
+      "Bash(git config --get:*)",
+      "Bash(git ls-files:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh repo view:*)",
+      "Bash(node:*)",
+      "Bash(pnpm:*)",
+      "Read(docs/**)"
+    ],
+    "deny": [
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(git reset:*)",
+      "Bash(git restore:*)",
+      "Bash(git clean:*)",
+      "Bash(git rebase:*)",
+      "Bash(git merge:*)",
+      "Bash(git checkout:*)",
+      "Bash(git switch:*)",
+      "Bash(git stash:*)"
+    ]
+  },
+  "hooks": {
+    "Stop": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "bash .claude/hooks/check-tasks.sh"
+      }]
+    }]
+  },
+  "defaultMode": "plan",
+  "skipAutoPermissionPrompt": false
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # src: .gitignore
-# @(#) : mainly ignored files and directories
+# @(#) : main ignore settings: ci-platform
 #
 # Copyright (c) 2026- atsushifx <http://github.com/atsushifx>
 #
@@ -63,6 +63,9 @@ releases/*
 
 # claude code setting
 .claude/*
+
+# settings
+!.claude/**/settings.json
 
 # agents can tracking
 !**/CLAUDE*.md

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,7 +9,7 @@
 pre-commit:
   parallel: true
   commands:
-    gitleaks:
+    betterleaks:
       run: betterleaks protect --config ./configs/betterleaks.toml
 
     secretlint:


### PR DESCRIPTION
## Overview

**Summary**
Add `.claude/settings.json` to configure Claude Code permissions and hooks, expose it via `.gitignore`, and rename the `lefthook.yml` pre-commit key to match the current tool name.

**Background / Motivation**
Claude Code's default behavior triggers frequent permission prompts, hurting developer experience. This PR adds an explicit allow/deny list to reduce noise while keeping destructive git operations guarded. The `lefthook.yml` command key also needed to match the actual tool name (`betterleaks`) for consistency.

## Changes

### Core Changes

- **`.claude/settings.json`** (new): defines allowed read-only git/gh/node commands, denies destructive git operations, registers a `Stop` hook to run `check-tasks.sh`, and sets `defaultMode` to `"plan"`
- **`.gitignore`**: adds `!.claude/**/settings.json` exception so the settings file is tracked by git while other `.claude/*` files remain ignored
- **`lefthook.yml`**: renames the pre-commit command key from `gitleaks` to `betterleaks` (no logic change)

### Test Updates

N/A

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [ ] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [ ] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

Verify after merge:
- `lefthook run pre-commit` passes with `betterleaks`
- `git ls-files .claude/` shows `settings.json` is tracked
- Claude Code runs `git status` without a permission prompt
- Claude Code blocks `git commit` (deny list confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
