### PR TITLE
feat(composite-actions): add setup-tool-repo composite action

### DIFF
--- a/.github/actions/setup-tool-repo/action.yml
+++ b/.github/actions/setup-tool-repo/action.yml
@@ -1,0 +1,96 @@
+# src: ./.github/actions/setup-tool-repo/action.yml
+# @(#) : composite GitHub Action to setup a tool repository with pnpm install
+
+name: "setup-tool-repo"
+description: "Setup a tool repository: validate, checkout, pnpm install, and add bin/ to PATH"
+
+inputs:
+  repo:
+    description: "GitHub repository in owner/repo format"
+    required: true
+  path:
+    description: "Local checkout path starting with ./"
+    required: true
+  ref:
+    description: "Git ref (tag, branch, or SHA)"
+    required: true
+  node-version:
+    description: "Node.js version"
+    required: false
+    default: "22"
+  pnpm-version:
+    description: "pnpm version"
+    required: false
+    default: "10"
+
+runs:
+  using: composite
+  steps:
+    - name: validate-inputs
+      shell: bash
+      run: |
+        # shellcheck source=/dev/null
+        . "${{ github.action_path }}/scripts/_libs/validate-inputs.lib.sh"
+        validate_inputs "${REPO}" "${PATH_DIR}" "${REF}"
+      env:
+        REPO: ${{ inputs.repo }}
+        PATH_DIR: ${{ inputs.path }}
+        REF: ${{ inputs.ref }}
+
+    - name: check-existing-repo
+      id: check-existing-repo
+      shell: bash
+      run: |
+        # shellcheck source=/dev/null
+        . "${{ github.action_path }}/scripts/_libs/check-existing.lib.sh"
+        check_existing "${REPO}" "${PATH_DIR}"
+      env:
+        REPO: ${{ inputs.repo }}
+        PATH_DIR: ${{ inputs.path }}
+
+    - name: setup-pnpm
+      uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+      with:
+        version: ${{ inputs.pnpm-version }}
+
+    - name: setup-node
+      uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: "pnpm"
+        cache-dependency-path: ${{ inputs.path }}/pnpm-lock.yaml
+
+    - name: checkout-repo
+      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      with:
+        repository: ${{ inputs.repo }}
+        path: ${{ inputs.path }}
+        ref: ${{ inputs.ref }}
+
+    - name: validate-repo-structure
+      if: steps.check-existing-repo.outputs.skip != 'true'
+      shell: bash
+      run: |
+        # shellcheck source=/dev/null
+        . "${{ github.action_path }}/scripts/_libs/validate-repo-structure.lib.sh"
+        validate_repo_structure "${PATH_DIR}"
+      env:
+        PATH_DIR: ${{ inputs.path }}
+
+    - name: install-packages
+      if: steps.check-existing-repo.outputs.skip != 'true'
+      shell: bash
+      working-directory: ${{ inputs.path }}
+      run: pnpm install --frozen-lockfile
+
+    - name: verify-and-add-path
+      shell: bash
+      run: |
+        # shellcheck source=/dev/null
+        . "${{ github.action_path }}/scripts/_libs/verify-and-add-path.lib.sh"
+        verify_and_add_path "${PATH_DIR}" "${REPO}" "${REF}"
+      env:
+        REPO: ${{ inputs.repo }}
+        PATH_DIR: ${{ inputs.path }}
+        REF: ${{ inputs.ref }}
+        SKIP_REPO: ${{ steps.check-existing-repo.outputs.skip }}

--- a/.github/actions/setup-tool-repo/scripts/__tests__/integration/setup-tool-repo.integration.spec.sh
+++ b/.github/actions/setup-tool-repo/scripts/__tests__/integration/setup-tool-repo.integration.spec.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# src: .github/actions/setup-tool-repo/scripts/__tests__/integration/setup-tool-repo.integration.spec.sh
+# @(#) : ShellSpec integration tests for setup-tool-repo composite action
+# shellcheck shell=bash
+
+# cspell:words mytool agla
+
+Include "${SHELLSPEC_PROJECT_ROOT}/.github/actions/setup-tool-repo/scripts/_libs/validate-inputs.lib.sh"
+Include "${SHELLSPEC_PROJECT_ROOT}/.github/actions/setup-tool-repo/scripts/_libs/check-existing.lib.sh"
+Include "${SHELLSPEC_PROJECT_ROOT}/.github/actions/setup-tool-repo/scripts/_libs/validate-repo-structure.lib.sh"
+Include "${SHELLSPEC_PROJECT_ROOT}/.github/actions/setup-tool-repo/scripts/_libs/verify-and-add-path.lib.sh"
+
+# ─── Internal Helpers
+
+setup_env() {
+  _TEST_DIR=$(mktemp -d)
+  GITHUB_PATH=$(mktemp)
+  GITHUB_ENV=$(mktemp)
+  GITHUB_OUTPUT=$(mktemp)
+  REPO_LOCK_DIR="${_TEST_DIR}/.repo.lock"
+  mkdir "${REPO_LOCK_DIR}"
+  SKIP_REPO="false"
+  mkdir -p "${_TEST_DIR}/node_modules/.bin"
+  mkdir -p "${_TEST_DIR}/bin"
+  printf '#!/bin/bash\necho hello\n' > "${_TEST_DIR}/bin/mytool"
+  touch "${_TEST_DIR}/pnpm-lock.yaml"
+}
+
+cleanup_env() {
+  rm -f "${GITHUB_PATH}" "${GITHUB_ENV}" "${GITHUB_OUTPUT}"
+  rm -rf "${_TEST_DIR}"
+}
+
+_run_integration_flow() {
+  validate_inputs "owner/repo" "./tools/agla" "v1.0.0" || return 1
+  validate_repo_structure "${_TEST_DIR}" || return 1
+  verify_and_add_path "${_TEST_DIR}" "owner/repo" "abc123" || return 1
+}
+
+# ─── Tests
+
+# T-05-01: [正常] 正常系統合フロー
+
+Describe 'Given: valid inputs, pnpm-lock.yaml and bin/ exist, node_modules/.bin/ exists'
+  BeforeEach 'setup_env'
+  AfterEach 'cleanup_env'
+
+  Describe 'When: validate_inputs, validate_repo_structure, verify_and_add_path are called in sequence'
+    Describe 'Then: Task T-05-01 - all libraries pass and GITHUB_PATH is updated'
+      It "T-05-01-01: exits 0 and GITHUB_PATH contains bin/ path"
+        When call _run_integration_flow
+        The status should equal 0
+        The contents of file "${GITHUB_PATH}" should include "${_TEST_DIR}/bin"
+      End
+    End
+  End
+End
+
+# T-05-02: [異常] 異常系統合フロー
+
+Describe 'Given: invalid repo format (no slash)'
+  BeforeEach 'setup_env'
+  AfterEach 'cleanup_env'
+
+  Describe 'When: validate_inputs is called with repo="agla-doc-tools"'
+    Describe 'Then: Task T-05-02-01 - validate_inputs fails before subsequent scripts'
+      It "T-05-02-01: exits 1 and stderr contains ::error::"
+        When run validate_inputs "agla-doc-tools" "./tools/agla" "v1.0.0"
+        The stderr should include "::error::"
+        The status should equal 1
+      End
+    End
+  End
+End
+
+Describe 'Given: path/.repo contains different repo (other/repo@abc123)'
+  BeforeEach 'setup_env'
+  AfterEach 'cleanup_env'
+
+  Describe 'When: check_existing is called with repo="owner/repo" but .repo has "other/repo@abc123"'
+    Describe 'Then: Task T-05-02-02 - check_existing exits 1 on repo conflict'
+      It "T-05-02-02: exits 1 and stderr contains ::error::"
+        printf 'other/repo@abc123' > "${_TEST_DIR}/.repo"
+        When run check_existing "owner/repo" "${_TEST_DIR}"
+        The stderr should include "::error::"
+        The status should equal 1
+      End
+    End
+  End
+End

--- a/.github/actions/setup-tool-repo/scripts/__tests__/unit/check-existing.unit.spec.sh
+++ b/.github/actions/setup-tool-repo/scripts/__tests__/unit/check-existing.unit.spec.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# src: .github/actions/setup-tool-repo/scripts/__tests__/unit/check-existing.unit.spec.sh
+# @(#) : ShellSpec unit tests for check-existing.lib.sh
+# shellcheck shell=bash
+
+Include "${SHELLSPEC_PROJECT_ROOT}/.github/actions/setup-tool-repo/scripts/_libs/check-existing.lib.sh"
+
+# ─── Internal Helpers
+
+setup_env() {
+  GITHUB_OUTPUT=$(mktemp)
+  GITHUB_ENV=$(mktemp)
+  _TEST_DIR=$(mktemp -d)
+}
+
+cleanup_env() {
+  rm -f "${GITHUB_OUTPUT}" "${GITHUB_ENV}"
+  rm -rf "${_TEST_DIR}"
+}
+
+# ─── Tests
+
+Describe 'Given: path directory does not exist'
+  BeforeEach 'setup_env'
+  AfterEach 'cleanup_env'
+  Describe 'When: check_existing is called'
+    Describe 'Then: Task T-02-01 - skip=false is written to GITHUB_OUTPUT'
+      It "T-02-01-01: skip=false in GITHUB_OUTPUT and REPO_LOCK_DIR in GITHUB_ENV"
+        _non_existent="${_TEST_DIR}/non-existent"
+        When call check_existing "owner/repo" "${_non_existent}"
+        The status should equal 0
+        The contents of file "${GITHUB_OUTPUT}" should include "skip=false"
+        The contents of file "${GITHUB_ENV}" should include "REPO_LOCK_DIR="
+      End
+    End
+  End
+End
+
+Describe 'Given: path exists and .repo matches input repo'
+  BeforeEach 'setup_env'
+  AfterEach 'cleanup_env'
+  Describe 'When: check_existing is called with matching repo'
+    Describe 'Then: Task T-02-02 - skip=true is written to GITHUB_OUTPUT'
+      It "T-02-02-01: skip=true in GITHUB_OUTPUT"
+        printf 'owner/repo@abc123' > "${_TEST_DIR}/.repo"
+        When call check_existing "owner/repo" "${_TEST_DIR}"
+        The status should equal 0
+        The contents of file "${GITHUB_OUTPUT}" should include "skip=true"
+      End
+    End
+    Describe 'Then: Task T-02-06 - skip=true and REPO_LOCK_DIR in GITHUB_ENV'
+      It "T-02-06-01: skip=true in GITHUB_OUTPUT and REPO_LOCK_DIR in GITHUB_ENV"
+        printf 'owner/repo@abc123' > "${_TEST_DIR}/.repo"
+        When call check_existing "owner/repo" "${_TEST_DIR}"
+        The status should equal 0
+        The contents of file "${GITHUB_OUTPUT}" should include "skip=true"
+        The contents of file "${GITHUB_ENV}" should include "REPO_LOCK_DIR="
+      End
+    End
+  End
+End
+
+Describe 'Given: path exists but .repo is missing'
+  BeforeEach 'setup_env'
+  AfterEach 'cleanup_env'
+  Describe 'When: check_existing is called'
+    Describe 'Then: Task T-02-03 - error and exit 1'
+      It "T-02-03-01: stderr contains ::error:: and exits 1"
+        When run check_existing "owner/repo" "${_TEST_DIR}"
+        The stderr should include "::error::"
+        The status should equal 1
+      End
+    End
+  End
+End
+
+Describe 'Given: .repo contains a different repo'
+  BeforeEach 'setup_env'
+  AfterEach 'cleanup_env'
+  Describe 'When: check_existing is called with mismatched repo'
+    Describe 'Then: Task T-02-04 - error and exit 1'
+      It "T-02-04-01: stderr contains ::error:: and exits 1"
+        printf 'other/repo@abc123' > "${_TEST_DIR}/.repo"
+        When run check_existing "owner/repo" "${_TEST_DIR}"
+        The stderr should include "::error::"
+        The status should equal 1
+      End
+    End
+  End
+End
+
+Describe 'Given: .repo.lock directory already exists'
+  BeforeEach 'setup_env'
+  AfterEach 'cleanup_env'
+  Describe 'When: check_existing is called'
+    Describe 'Then: Task T-02-05 - lock conflict error and exit 1'
+      It "T-02-05-01: stderr contains ::error:: and exits 1"
+        mkdir "${_TEST_DIR}/.repo.lock"
+        When run check_existing "owner/repo" "${_TEST_DIR}"
+        The stderr should include "::error::"
+        The status should equal 1
+      End
+    End
+  End
+End
+

--- a/.github/actions/setup-tool-repo/scripts/__tests__/unit/validate-inputs.unit.spec.sh
+++ b/.github/actions/setup-tool-repo/scripts/__tests__/unit/validate-inputs.unit.spec.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# src: .github/actions/setup-tool-repo/scripts/__tests__/unit/validate-inputs.unit.spec.sh
+# @(#) : ShellSpec unit tests for validate-inputs.lib.sh
+# shellcheck shell=bash
+
+Include "${SHELLSPEC_PROJECT_ROOT}/.github/actions/setup-tool-repo/scripts/_libs/validate-inputs.lib.sh"
+
+# ─── Tests
+
+Describe 'Given: valid inputs are provided'
+  Describe 'When: validate_inputs is called with owner/repo, ./tools/agla, v1.0.0'
+    Describe 'Then: Task T-01-01 - valid inputs are accepted'
+      It "T-01-01-01: exits 0"
+        When call validate_inputs "owner/repo" "./tools/agla" "v1.0.0"
+        The status should equal 0
+      End
+    End
+  End
+End
+
+Describe 'Given: repo has no slash (invalid format)'
+  Describe 'When: validate_inputs is called with an invalid repo'
+    Describe 'Then: Task T-01-02 - invalid repo is rejected'
+      It "T-01-02-01: repo without slash → stderr ::error:: and exits 1"
+        When run validate_inputs "agla-doc-tools" "./tools/agla" "v1.0.0"
+        The stderr should include "::error::"
+        The status should equal 1
+      End
+
+      It "T-01-02-02: repo with multiple slashes → stderr ::error:: and exits 1"
+        When run validate_inputs "owner/repo/extra" "./tools/agla" "v1.0.0"
+        The stderr should include "::error::"
+        The status should equal 1
+      End
+    End
+  End
+End
+
+Describe 'Given: path does not start with "./"'
+  Describe 'When: validate_inputs is called with an invalid path prefix'
+    Describe 'Then: Task T-01-03 - invalid path is rejected'
+      It "T-01-03-01: relative path without ./ → stderr ::error:: and exits 1"
+        When run validate_inputs "owner/repo" "tools/agla" "v1.0.0"
+        The stderr should include "::error::"
+        The status should equal 1
+      End
+
+      It "T-01-03-03: absolute path → stderr ::error:: and exits 1"
+        When run validate_inputs "owner/repo" "/tmp/tools" "v1.0.0"
+        The stderr should include "::error::"
+        The status should equal 1
+      End
+    End
+  End
+End
+
+Describe 'Given: path contains ".." segment'
+  Describe 'When: validate_inputs is called with path="./foo/../bar"'
+    Describe 'Then: Task T-01-03 - path traversal is rejected'
+      It "T-01-03-02: path with .. traversal → stderr ::error:: and exits 1"
+        When run validate_inputs "owner/repo" "./foo/../bar" "v1.0.0"
+        The stderr should include "::error::"
+        The status should equal 1
+      End
+    End
+  End
+End
+
+Describe 'Given: ref is empty string'
+  Describe 'When: validate_inputs is called with ref=""'
+    Describe 'Then: Task T-01-04 - empty ref is rejected'
+      It "T-01-04-01: stderr contains ::error:: and exits 1"
+        When run validate_inputs "owner/repo" "./tools/agla" ""
+        The stderr should include "::error::"
+        The status should equal 1
+      End
+    End
+  End
+End
+
+Describe 'Given: path contains ".." within a segment (not a traversal)'
+  Describe 'When: validate_inputs is called with path="./foo..bar"'
+    Describe 'Then: Task T-01-05 - segment-internal ".." is accepted'
+      It "T-01-05-01: exits 0 (no path traversal)"
+        When call validate_inputs "owner/repo" "./foo..bar" "v1.0.0"
+        The status should equal 0
+      End
+    End
+  End
+End
+
+Describe 'Given: path="../outside" (starts with .. not ./)'
+  Describe 'When: validate_inputs is called with path="../outside"'
+    Describe 'Then: Task T-01-05 - path not starting with ./ is rejected'
+      It "T-01-05-02: path='../outside' は exit 1 になる"
+        When run validate_inputs "owner/repo" "../outside" "v1.0.0"
+        The stderr should include "::error::"
+        The status should equal 1
+      End
+    End
+  End
+End
+
+Describe 'Given: ref is whitespace-only string'
+  Describe 'When: validate_inputs is called with ref="  "'
+    Describe 'Then: Task T-01-04 - whitespace-only ref is rejected'
+      It "T-01-04-02: stderr contains ::error:: and exits 1"
+        When run validate_inputs "owner/repo" "./tools/agla" "  "
+        The stderr should include "::error::"
+        The status should equal 1
+      End
+    End
+  End
+End

--- a/.github/actions/setup-tool-repo/scripts/__tests__/unit/validate-repo-structure.unit.spec.sh
+++ b/.github/actions/setup-tool-repo/scripts/__tests__/unit/validate-repo-structure.unit.spec.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# src: .github/actions/setup-tool-repo/scripts/__tests__/unit/validate-repo-structure.unit.spec.sh
+# @(#) : ShellSpec unit tests for validate-repo-structure.lib.sh
+# shellcheck shell=bash
+
+Include "${SHELLSPEC_PROJECT_ROOT}/.github/actions/setup-tool-repo/scripts/_libs/validate-repo-structure.lib.sh"
+
+# ─── Internal Helpers
+
+setup_dir() { _TEST_DIR=$(mktemp -d); }
+cleanup_dir() { rm -rf "${_TEST_DIR}"; }
+
+# ─── Tests
+
+Describe 'Given: pnpm-lock.yaml and bin/ both exist'
+  BeforeEach 'setup_dir'
+  AfterEach 'cleanup_dir'
+  Describe 'When: validate_repo_structure is called'
+    Describe 'Then: Task T-03-01 - valid structure is accepted'
+      It "T-03-01-01: exits 0"
+        touch "${_TEST_DIR}/pnpm-lock.yaml"
+        mkdir "${_TEST_DIR}/bin"
+        When call validate_repo_structure "${_TEST_DIR}"
+        The status should equal 0
+      End
+    End
+  End
+End
+
+Describe 'Given: pnpm-lock.yaml does not exist'
+  BeforeEach 'setup_dir'
+  AfterEach 'cleanup_dir'
+  Describe 'When: validate_repo_structure is called'
+    Describe 'Then: Task T-03-02 - missing pnpm-lock.yaml is rejected'
+      It "T-03-02-01: stderr contains ::error:: and exits 1"
+        mkdir "${_TEST_DIR}/bin"
+        When run validate_repo_structure "${_TEST_DIR}"
+        The stderr should include "::error::"
+        The status should equal 1
+      End
+    End
+  End
+End
+
+Describe 'Given: bin/ directory does not exist'
+  BeforeEach 'setup_dir'
+  AfterEach 'cleanup_dir'
+  Describe 'When: validate_repo_structure is called'
+    Describe 'Then: Task T-03-03 - missing bin/ is rejected'
+      It "T-03-03-01: stderr contains ::error:: and exits 1"
+        touch "${_TEST_DIR}/pnpm-lock.yaml"
+        When run validate_repo_structure "${_TEST_DIR}"
+        The stderr should include "::error::"
+        The status should equal 1
+      End
+    End
+  End
+End

--- a/.github/actions/setup-tool-repo/scripts/__tests__/unit/verify-and-add-path.unit.spec.sh
+++ b/.github/actions/setup-tool-repo/scripts/__tests__/unit/verify-and-add-path.unit.spec.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# src: .github/actions/setup-tool-repo/scripts/__tests__/unit/verify-and-add-path.unit.spec.sh
+# @(#) : ShellSpec unit tests for verify-and-add-path.lib.sh
+# shellcheck shell=bash
+
+# cspell:words mytool
+
+
+Include "${SHELLSPEC_PROJECT_ROOT}/.github/actions/setup-tool-repo/scripts/_libs/verify-and-add-path.lib.sh"
+
+# ─── Internal Helpers
+
+setup_env() {
+  GITHUB_PATH=$(mktemp)
+  GITHUB_ENV=$(mktemp)
+  _TEST_DIR=$(mktemp -d)
+  REPO_LOCK_DIR="${_TEST_DIR}/.repo.lock"
+  mkdir "${REPO_LOCK_DIR}"
+  SKIP_REPO="false"
+}
+
+cleanup_env() {
+  rm -f "${GITHUB_PATH}" "${GITHUB_ENV}"
+  rm -rf "${_TEST_DIR}"
+}
+
+# ─── Tests
+
+# T-04-01: [正常] skip=false（新規チェックアウト）
+
+Describe 'Given: node_modules/.bin/ exists, bin/ has executable file, SKIP_REPO=false'
+  BeforeEach 'setup_env'
+  AfterEach 'cleanup_env'
+  Describe 'When: verify_and_add_path is called'
+    Describe 'Then: Task T-04-01 - GITHUB_PATH appended, .repo written, lock released'
+      It "T-04-01-01: exits 0, bin/ in GITHUB_PATH, .repo has owner/repo@sha, lock removed"
+        mkdir -p "${_TEST_DIR}/node_modules/.bin"
+        mkdir -p "${_TEST_DIR}/bin"
+        printf '#!/bin/bash\necho hello\n' > "${_TEST_DIR}/bin/mytool"
+        chmod +x "${_TEST_DIR}/bin/mytool"
+        SKIP_REPO="false"
+        When call verify_and_add_path "${_TEST_DIR}" "owner/repo" "abc123"
+        The status should equal 0
+        The contents of file "${GITHUB_PATH}" should include "${_TEST_DIR}/bin"
+        The contents of file "${_TEST_DIR}/.repo" should equal "owner/repo@abc123"
+        The path "${_TEST_DIR}/.repo.lock" should not be exist
+      End
+    End
+  End
+End
+
+# T-04-02: [正常] skip=true（既存チェックアウト再利用）
+
+Describe 'Given: node_modules/.bin/ exists, bin/ has executable file, SKIP_REPO=true'
+  BeforeEach 'setup_env'
+  AfterEach 'cleanup_env'
+  Describe 'When: verify_and_add_path is called'
+    Describe 'Then: Task T-04-02 - GITHUB_PATH appended, .repo NOT written, lock released'
+      It "T-04-02-01: exits 0, bin/ in GITHUB_PATH, no .repo file, lock removed"
+        mkdir -p "${_TEST_DIR}/node_modules/.bin"
+        mkdir -p "${_TEST_DIR}/bin"
+        printf '#!/bin/bash\necho hello\n' > "${_TEST_DIR}/bin/mytool"
+        SKIP_REPO="true"
+        When call verify_and_add_path "${_TEST_DIR}" "owner/repo" "abc123"
+        The status should equal 0
+        The contents of file "${GITHUB_PATH}" should include "${_TEST_DIR}/bin"
+        The path "${_TEST_DIR}/.repo" should not be exist
+        The path "${_TEST_DIR}/.repo.lock" should not be exist
+      End
+    End
+  End
+End
+
+# T-04-03: [異常] post-install 検証の失敗ケース
+
+Describe 'Given: node_modules/.bin/ does not exist'
+  BeforeEach 'setup_env'
+  AfterEach 'cleanup_env'
+  Describe 'When: verify_and_add_path is called'
+    Describe 'Then: Task T-04-03-01 - R-015 error, exit 1, lock remains'
+      It "T-04-03-01: stderr contains ::error:: and exits 1, .repo.lock still exists"
+        mkdir -p "${_TEST_DIR}/bin"
+        printf '#!/bin/bash\necho hello\n' > "${_TEST_DIR}/bin/mytool"
+        When run verify_and_add_path "${_TEST_DIR}" "owner/repo" "abc123"
+        The stderr should include "::error::"
+        The status should equal 1
+        The path "${_TEST_DIR}/.repo.lock" should be exist
+      End
+    End
+  End
+End
+
+Describe 'Given: node_modules/.bin/ exists, bin/ is empty directory'
+  BeforeEach 'setup_env'
+  AfterEach 'cleanup_env'
+  Describe 'When: verify_and_add_path is called'
+    Describe 'Then: Task T-04-03-02 - R-016 error, exit 1, lock remains'
+      It "T-04-03-02: stderr contains ::error:: and exits 1, .repo.lock still exists"
+        mkdir -p "${_TEST_DIR}/node_modules/.bin"
+        mkdir -p "${_TEST_DIR}/bin"
+        When run verify_and_add_path "${_TEST_DIR}" "owner/repo" "abc123"
+        The stderr should include "::error::"
+        The status should equal 1
+        The path "${_TEST_DIR}/.repo.lock" should be exist
+      End
+    End
+  End
+End
+
+Describe 'Given: node_modules/.bin/ exists, bin/ has non-executable file (touch)'
+  BeforeEach 'setup_env'
+  AfterEach 'cleanup_env'
+  Describe 'When: verify_and_add_path is called'
+    Describe 'Then: Task T-04-03-03 - R-017 error, exit 1, lock remains'
+      It "T-04-03-03: stderr contains ::error:: and exits 1, .repo.lock still exists"
+        mkdir -p "${_TEST_DIR}/node_modules/.bin"
+        mkdir -p "${_TEST_DIR}/bin"
+        touch "${_TEST_DIR}/bin/noexec_tool"
+        When run verify_and_add_path "${_TEST_DIR}" "owner/repo" "abc123"
+        The stderr should include "::error::"
+        The status should equal 1
+        The path "${_TEST_DIR}/.repo.lock" should be exist
+      End
+    End
+  End
+End
+
+# T-04-05: [エッジケース] node_modules/.bin/ が空ディレクトリでも pass する
+
+Describe 'Given: node_modules/.bin/ exists but is empty, bin/ has executable file'
+  BeforeEach 'setup_env'
+  AfterEach 'cleanup_env'
+  Describe 'When: verify_and_add_path is called'
+    Describe 'Then: Task T-04-05-01 - R-015 checks directory existence only, exit 0'
+      It "T-04-05-01: exits 0 (node_modules/.bin/ empty dir is acceptable)"
+        mkdir -p "${_TEST_DIR}/node_modules/.bin"
+        mkdir -p "${_TEST_DIR}/bin"
+        printf '#!/bin/bash\necho hello\n' > "${_TEST_DIR}/bin/mytool"
+        When call verify_and_add_path "${_TEST_DIR}" "owner/repo" "abc123"
+        The status should equal 0
+      End
+    End
+  End
+End
+
+# T-04-06: [エッジケース] bin/ 配下にシンボリックリンクのみ存在する場合
+
+Describe 'Given: bin/ has only a symlink pointing to an executable target'
+  BeforeEach 'setup_env'
+  AfterEach 'cleanup_env'
+  Describe 'When: verify_and_add_path is called'
+    Describe 'Then: Task T-04-06-01 - symlink with exec target passes R-017, exit 0'
+      It "T-04-06-01: exits 0 (symlink to executable file)"
+        mkdir -p "${_TEST_DIR}/node_modules/.bin"
+        mkdir -p "${_TEST_DIR}/bin"
+        _real="${_TEST_DIR}/real_exec"
+        printf '#!/bin/bash\necho hello\n' > "${_real}"
+        MSYS=winsymlinks:nativestrict ln -s "${_real}" "${_TEST_DIR}/bin/mytool"
+        When call verify_and_add_path "${_TEST_DIR}" "owner/repo" "abc123"
+        The status should equal 0
+      End
+    End
+  End
+End
+
+Describe 'Given: bin/ has only a symlink pointing to a non-executable target (touch)'
+  BeforeEach 'setup_env'
+  AfterEach 'cleanup_env'
+  Describe 'When: verify_and_add_path is called'
+    Describe 'Then: Task T-04-06-02 - symlink with non-exec target fails R-017, exit 1'
+      It "T-04-06-02: stderr contains ::error:: and exits 1 (symlink to non-executable file)"
+        mkdir -p "${_TEST_DIR}/node_modules/.bin"
+        mkdir -p "${_TEST_DIR}/bin"
+        _real="${_TEST_DIR}/real_noexec"
+        touch "${_real}"
+        MSYS=winsymlinks:nativestrict ln -s "${_real}" "${_TEST_DIR}/bin/mytool"
+        When run verify_and_add_path "${_TEST_DIR}" "owner/repo" "abc123"
+        The stderr should include "::error::"
+        The status should equal 1
+      End
+    End
+  End
+End

--- a/.github/actions/setup-tool-repo/scripts/_libs/check-existing.lib.sh
+++ b/.github/actions/setup-tool-repo/scripts/_libs/check-existing.lib.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# src: .github/actions/setup-tool-repo/scripts/_libs/check-existing.lib.sh
+# @(#) : check_existing — 既存チェックアウト確認とロック取得ライブラリ
+# shellcheck shell=bash
+
+[ -n "${CHECK_EXISTING_LIB_LOADED:-}" ] && return 0
+CHECK_EXISTING_LIB_LOADED=1
+
+##
+# @description Check if a tool repo checkout already exists and acquire a lock.
+# @arg $1 repo — "owner/repo" format
+# @arg $2 path — directory path where the repo would be checked out
+# @return 0 on success (writes skip=true/false to GITHUB_OUTPUT, REPO_LOCK_DIR to GITHUB_ENV)
+# @return 1 on failure (lock conflict, missing .repo, or repo mismatch)
+check_existing() {
+  local _repo="$1"
+  local _path="$2"
+  local _lock_dir="${_path}/.repo.lock"
+
+  # 1. Capture whether path existed before any mkdir
+  local _path_existed
+  [[ -d "${_path}" ]] && _path_existed=true || _path_existed=false
+
+  # 2. Ensure parent exists so atomic lock mkdir can succeed
+  mkdir -p "${_path}"
+
+  # 3. Lock acquisition (atomic mkdir — fails if lock already exists)
+  if ! mkdir "${_lock_dir}" 2>/dev/null; then
+    echo "::error::check-existing: lock conflict: ${_lock_dir} already exists" >&2
+    return 1
+  fi
+
+  # 4. Write REPO_LOCK_DIR to GITHUB_ENV (required in all success paths)
+  echo "REPO_LOCK_DIR=${_lock_dir}" >> "${GITHUB_ENV}"
+
+  # 5. Path exists: validate .repo
+  if [[ "${_path_existed}" == true ]]; then
+    # .repo missing → error
+    if [[ ! -f "${_path}/.repo" ]]; then
+      echo "::error::check-existing: path exists but .repo is missing: ${_path}" >&2
+      return 1
+    fi
+
+    # Parse .repo and compare; mismatch → error
+    local _recorded
+    _recorded=$(< "${_path}/.repo")
+    local _recorded_repo="${_recorded%%@*}"
+
+    if [[ "${_recorded_repo}" != "${_repo}" ]]; then
+      echo "::error::check-existing: repo conflict: expected '${_repo}', found '${_recorded_repo}'" >&2
+      return 1
+    fi
+
+    echo "skip=true" >> "${GITHUB_OUTPUT}"
+    return 0
+  fi
+
+  # 6. Path didn't exist → new checkout
+  echo "skip=false" >> "${GITHUB_OUTPUT}"
+  return 0
+}

--- a/.github/actions/setup-tool-repo/scripts/_libs/validate-inputs.lib.sh
+++ b/.github/actions/setup-tool-repo/scripts/_libs/validate-inputs.lib.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# src: .github/actions/setup-tool-repo/scripts/_libs/validate-inputs.lib.sh
+# @(#) : validate_inputs — repo/path/ref パラメータ検証ライブラリ
+# shellcheck shell=bash
+
+[ -n "${VALIDATE_INPUTS_LIB_LOADED:-}" ] && return 0
+VALIDATE_INPUTS_LIB_LOADED=1
+
+SCRIPT_DIR="${BASH_SOURCE[0]%/*}"
+
+# shellcheck source=/dev/null
+. "${SCRIPT_DIR}/../../../_libs/validation.lib.sh"
+
+##
+# @description Validate repo, path, and ref input parameters.
+# @arg $1 repo — "owner/repo" format (required)
+# @arg $2 path — must start with "./" and contain no ".." segments (required)
+# @arg $3 ref  — non-empty string (required)
+# @return 0 on success, 1 on failure (stderr contains ::error:: message)
+validate_inputs() {
+  local _repo="$1"
+  local _path="$2"
+  local _ref="$3"
+
+  validate_repo "$_repo" "repo" || return 1
+
+  if [[ "$_path" != "./"* ]]; then
+    echo "::error::validate-inputs: path must start with './' (got: '${_path}')" >&2
+    return 1
+  fi
+
+  local _segment
+  local -a _segments
+  IFS='/' read -ra _segments <<< "$_path"
+  for _segment in "${_segments[@]}"; do
+    if [[ "$_segment" == ".." ]]; then
+      echo "::error::validate-inputs: path must not contain '..' segments (got: '${_path}')" >&2
+      return 1
+    fi
+  done
+
+  if [[ -z "${_ref// /}" ]]; then
+    echo "::error::validate-inputs: ref must not be empty" >&2
+    return 1
+  fi
+
+  return 0
+}

--- a/.github/actions/setup-tool-repo/scripts/_libs/validate-repo-structure.lib.sh
+++ b/.github/actions/setup-tool-repo/scripts/_libs/validate-repo-structure.lib.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# src: .github/actions/setup-tool-repo/scripts/_libs/validate-repo-structure.lib.sh
+# @(#) : validate_repo_structure — チェックアウト済みリポジトリ構造検証ライブラリ
+# shellcheck shell=bash
+
+[ -n "${VALIDATE_REPO_STRUCTURE_LIB_LOADED:-}" ] && return 0
+VALIDATE_REPO_STRUCTURE_LIB_LOADED=1
+
+##
+# @description Validate that a checked-out tool repo has the expected file structure.
+# @arg $1 path — path to the checked-out repository root
+# @return 0 on success, 1 on failure (stderr contains ::error:: message)
+validate_repo_structure() {
+  local _path="$1"
+
+  if [[ ! -f "${_path}/pnpm-lock.yaml" ]]; then
+    echo "::error::validate-repo-structure: pnpm-lock.yaml not found in '${_path}'" >&2
+    return 1
+  fi
+
+  if [[ ! -d "${_path}/bin" ]]; then
+    echo "::error::validate-repo-structure: bin/ directory not found in '${_path}'" >&2
+    return 1
+  fi
+
+  return 0
+}

--- a/.github/actions/setup-tool-repo/scripts/_libs/verify-and-add-path.lib.sh
+++ b/.github/actions/setup-tool-repo/scripts/_libs/verify-and-add-path.lib.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# src: .github/actions/setup-tool-repo/scripts/_libs/verify-and-add-path.lib.sh
+# @(#) : verify_and_add_path — インストール後検証とPATH追加ライブラリ
+# shellcheck shell=bash
+
+[ -n "${VERIFY_AND_ADD_PATH_LIB_LOADED:-}" ] && return 0
+VERIFY_AND_ADD_PATH_LIB_LOADED=1
+
+##
+# @description Verify post-install structure and add bin/ to GITHUB_PATH.
+# @arg $1 _path    — checked-out repo root
+# @arg $2 _repo    — "owner/repo" format
+# @arg $3 _sha     — commit SHA
+# @env SKIP_REPO     — "true" or "false"
+# @env REPO_LOCK_DIR — path to .repo.lock directory
+# @env GITHUB_PATH   — path to github path file
+# @return 0 on success, 1 on failure
+verify_and_add_path() {
+  local _path="$1"
+  local _repo="$2"
+  local _sha="$3"
+
+  # R-015: node_modules/.bin/ must exist
+  if [[ ! -d "${_path}/node_modules/.bin" ]]; then
+    echo "::error::verify-and-add-path: node_modules/.bin/ not found: ${_path}/node_modules/.bin" >&2
+    return 1
+  fi
+
+  # R-016: bin/ must contain at least one file
+  local _has_file=false
+  for _f in "${_path}/bin/"*; do
+    [[ -e "${_f}" ]] || continue
+    _has_file=true
+    break
+  done
+  if [[ "${_has_file}" == false ]]; then
+    echo "::error::verify-and-add-path: no files found in ${_path}/bin/" >&2
+    return 1
+  fi
+
+  # R-017: all files in bin/ must have execute permission
+  for _f in "${_path}/bin/"*; do
+    [[ -e "${_f}" ]] || continue
+    # shebang があれば実行ビットを付与（Windows では chmod が必要）
+    if head -c 2 "${_f}" 2>/dev/null | grep -q '^#!'; then
+      chmod +x "${_f}"
+    fi
+    if [[ ! -x "${_f}" ]]; then
+      echo "::error::verify-and-add-path: file not executable: ${_f}" >&2
+      return 1
+    fi
+  done
+
+  # R-019: append bin/ to GITHUB_PATH
+  echo "${_path}/bin" >> "${GITHUB_PATH}"
+
+  # R-020 / R-020S: write .repo unless SKIP_REPO=true
+  if [[ "${SKIP_REPO}" != "true" ]]; then
+    printf '%s@%s' "${_repo}" "${_sha}" > "${_path}/.repo"
+  fi
+
+  # Release lock
+  [[ -n "${REPO_LOCK_DIR:-}" ]] && rm -rf "${REPO_LOCK_DIR}"
+
+  return 0
+}

--- a/docs/.deckrd/composite-action/setup-tool-repo/implementation/implementation.md
+++ b/docs/.deckrd/composite-action/setup-tool-repo/implementation/implementation.md
@@ -1,0 +1,311 @@
+---
+title: "Implementation Plan: setup-tool-repo Composite Action"
+based-on: specifications.md v1.0.2
+status: Draft
+version: 1.0.5
+created: "2026-06-18"
+---
+
+<!-- textlint-disable
+  ja-technical-writing/sentence-length,
+  ja-technical-writing/no-exclamation-question-mark -->
+<!-- markdownlint-disable line-length -->
+
+## 1. Overview
+
+### 1.1 Purpose
+
+`setup-tool-repo` コンポジットアクションを実装する。
+`action.yml` と 4 本の bash スクリプトライブラリで構成し、
+仕様書（specifications.md v1.0.2）で定義した 7 ユニットの振る舞いを実現する。
+
+### 1.2 Reference
+
+- Prior Art: `.github/actions/setup-tool/`（同一リポジトリの参考実装）
+- Shared libs: `.github/actions/_libs/validation.lib.sh`（`validate_repo()` 再利用）
+- Specifications: `docs/.deckrd/composite-action/setup-tool-repo/specifications/specifications.md`
+
+### 1.3 Implementation Units → Files
+
+| Spec Unit                 | 実装場所                                       |
+| ------------------------- | ---------------------------------------------- |
+| validate-inputs           | `scripts/_libs/validate-inputs.lib.sh`         |
+| check-existing-repo       | `scripts/_libs/check-existing.lib.sh`          |
+| setup-environment         | `action.yml`（uses: ステップ直書き）           |
+| checkout-repo             | `action.yml`（uses: ステップ直書き）           |
+| validate-repo-structure   | `scripts/_libs/validate-repo-structure.lib.sh` |
+| install-packages          | `action.yml`（run: ステップ直書き）            |
+| verify-install + add-path | `scripts/_libs/verify-and-add-path.lib.sh`     |
+
+### 1.4 Directory Structure
+
+```text
+.github/actions/setup-tool-repo/
+├── action.yml
+└── scripts/
+    ├── _libs/
+    │   ├── validate-inputs.lib.sh
+    │   ├── check-existing.lib.sh
+    │   ├── validate-repo-structure.lib.sh
+    │   └── verify-and-add-path.lib.sh
+    └── __tests__/
+        ├── unit/
+        │   ├── validate-inputs.unit.spec.sh
+        │   ├── check-existing.unit.spec.sh
+        │   ├── validate-repo-structure.unit.spec.sh
+        │   └── verify-and-add-path.unit.spec.sh
+        └── integration/
+            └── setup-tool-repo.integration.spec.sh
+```
+
+---
+
+## 2. Implementation Plan
+
+### Phase 1: Foundation — action.yml + 入力検証
+
+#### Commit 1: feat(setup-tool-repo): add action.yml skeleton with inputs
+
+- `.github/actions/setup-tool-repo/action.yml` を新規作成
+- `inputs:` に `repo`（required）/ `path`（required）/ `ref`（required）/ `node-version`（default: `"22"`）/ `pnpm-version`（default: `"10"`）を定義
+- `permissions:` は**宣言しない**（コンポジットアクションでは宣言不可。呼び出し元 job で `contents: read` を設定する旨をコメントで明記）
+- `runs.using: composite`、ステップは空（後続フェーズで追加）
+
+#### Commit 2: feat(setup-tool-repo): add validate-inputs.lib.sh
+
+- `scripts/_libs/validate-inputs.lib.sh` を新規作成
+- `validate_repo()` 再利用（`.github/actions/_libs/validation.lib.sh`）で `repo` を検証
+- `path` の `./` 始まりチェック + セグメント単位の `..` 禁止チェック（R-002）
+- `ref` の非空・非空白チェック（R-003）
+- 失敗時は `::error::` フォーマットで stderr に出力し exit 1
+
+#### Commit 3: test(setup-tool-repo): add unit tests for validate-inputs
+
+- `scripts/__tests__/unit/validate-inputs.unit.spec.sh` を新規作成
+- 正常系: 有効な `repo`/`path`/`ref` ですべて pass
+- 異常系（R-001）: `repo` が `owner/repo` 形式でない → exit 1
+- 異常系（R-002）: `path` が `./` 始まりでない → exit 1
+- 異常系（R-002）: `path` に `..` セグメントを含む → exit 1
+- 異常系（R-002）: `path` が絶対パス → exit 1
+- 異常系（R-003）: `ref` が空文字列・空白のみ → exit 1
+- エッジケース: `./foo..bar`（`..` はセグメント内部）→ pass
+
+---
+
+### Phase 2: 既存チェックアウト検証
+
+#### Commit 4: feat(setup-tool-repo): add check-existing.lib.sh
+
+- `scripts/_libs/check-existing.lib.sh` を新規作成
+- `.repo` ファイルの形式: `<owner>/<repo>@<commit-sha>`
+- **ロック取得**（処理の最初に実行）:
+  - `<path>` が存在しない場合は `mkdir -p <path>` してからロック取得
+  - `mkdir "<path>/.repo.lock"` でアトミックにロックを取得（R-005 前処理）
+  - 取得失敗（同一 `path` で別プロセスが実行中）: `::error::` 出力 → exit 1
+  - ロックディレクトリパスを `REPO_LOCK_DIR=<path>/.repo.lock` として `GITHUB_ENV` に書き込み（`verify-and-add-path.sh` が解放するため）
+- `<path>` ディレクトリが存在しない場合（新規）: skip フラグ = false を `GITHUB_OUTPUT` に書き込み（R-005）
+- `<path>` が存在するが `<path>/.repo` がない場合: exit 1（R-006）
+- `.repo` から `<owner>/<repo>` 部分を抽出し、入力 `repo` と比較（R-007/R-008）
+  - 一致: skip フラグ = true を `GITHUB_OUTPUT` に書き込み（R-007）
+  - 不一致: exit 1（R-008）
+- `GITHUB_OUTPUT`/`GITHUB_ENV` は未設定時 `:?` でエラーにする（HARDEN-01）
+
+#### Commit 5: test(setup-tool-repo): add unit tests for check-existing
+
+- `scripts/__tests__/unit/check-existing.unit.spec.sh` を新規作成
+- `BeforeEach` で `GITHUB_OUTPUT`・`GITHUB_ENV` を `mktemp` で生成したファイルに設定（`:?` 検証を通過させるため）
+- `AfterEach` で一時ファイルを削除
+- 正常系（R-005）: `<path>` 不存在 → ロック取得、`skip=false` を出力、`GITHUB_ENV` に `REPO_LOCK_DIR` が書き込まれる
+- 正常系（R-007）: `.repo` が `owner/repo@<sha>` 形式で同一 repo → ロック取得、`skip=true` を出力
+- 異常系（R-006）: `<path>` 存在するが `.repo` なし → ロック取得後に exit 1
+- 異常系（R-008）: `.repo` の repo 部分が別 repo → ロック取得後に exit 1
+- 異常系（ロック競合）: `<path>/.repo.lock` が既に存在する → ロック取得失敗 → exit 1
+
+---
+
+### Phase 3: リポジトリ構造検証 + インストール後検証
+
+#### Commit 6: feat(setup-tool-repo): add validate-repo-structure.lib.sh
+
+- `scripts/_libs/validate-repo-structure.lib.sh` を新規作成
+- `<path>/pnpm-lock.yaml` の存在確認（R-011）→ 不存在で exit 1
+- `<path>/bin/` ディレクトリの存在確認（R-012）→ 不存在で exit 1
+- 注意:
+  skip フラグの処理は不要。`action.yml` の `if: steps.check-existing-repo.outputs.skip != 'true'` 条件でステップごとスキップされるため、
+  このスクリプト自体は常に検証のみを行う
+
+#### Commit 7: test(setup-tool-repo): add unit tests for validate-repo-structure
+
+- `scripts/__tests__/unit/validate-repo-structure.unit.spec.sh` を新規作成
+- 正常系: `pnpm-lock.yaml` + `bin/` 両方存在 → pass
+- 異常系（R-011）: `pnpm-lock.yaml` なし → exit 1
+- 異常系（R-012）: `bin/` なし → exit 1
+
+#### Commit 8: feat(setup-tool-repo): add verify-and-add-path.lib.sh
+
+- `scripts/_libs/verify-and-add-path.lib.sh` を新規作成
+- `<path>/node_modules/.bin/` 存在確認（R-015）→ 不存在で exit 1
+- `<path>/bin/` 配下ファイル存在確認（R-016）→ なければ exit 1
+- `<path>/bin/` 配下ファイルの実行権限確認（R-017）→ shebang（`#!`）があれば自動で `chmod +x`、それでも実行ビットがなければ exit 1
+- `<path>/bin/` の絶対パスを `echo >> "${GITHUB_PATH:?GITHUB_PATH is not set}"` で追記（R-019）
+- skip フラグ = false の場合: `git -C <path> rev-parse HEAD` で commit SHA を解決し、`<owner>/<repo>@<commit-sha>` 形式で `<path>/.repo` に書き込み（R-020、**HARDEN-04**: `mktemp` + `mv` で原子的に書き込む）
+- skip フラグ = true の場合: `.repo` 書き込みをスキップ（R-020S）
+- **ロック解放**（処理の最後に必ず実行）:
+  - `GITHUB_ENV` から `REPO_LOCK_DIR` を読み取り `rmdir "${REPO_LOCK_DIR}"` でロック解放
+  - `REPO_LOCK_DIR` が未設定または存在しない場合は無視（`|| true`）
+
+#### Commit 9: test(setup-tool-repo): add unit tests for verify-and-add-path
+
+- `scripts/__tests__/unit/verify-and-add-path.unit.spec.sh` を新規作成
+- 正常系（skip=false）: 全検証通過、`GITHUB_PATH` 追記、`.repo` に `owner/repo@<sha>` 形式で書き込み、ロック解放（`.repo.lock` が削除される）
+- 正常系（skip=true）: 全検証通過、`GITHUB_PATH` 追記、`.repo` 書き込みスキップ、ロック解放
+- 異常系（R-015）: `node_modules/.bin/` なし → exit 1（ロックは解放されない — 後続の再試行を防ぐ）
+- 異常系（R-016）: `bin/` 空ディレクトリ → exit 1
+- 異常系（R-017）: `bin/` 配下ファイルに shebang なし・実行権限なし → exit 1
+- 自動修復（R-017）: shebang あり・実行権限なし（Windows 環境等）→ `chmod +x` を自動適用してチェック通過（symlink はリンク先を読んで判定）
+
+---
+
+### Phase 4: 統合 — action.yml のステップ結合
+
+#### Commit 10: feat(setup-tool-repo): wire up action.yml steps
+
+- `action.yml` に以下のステップを順序通り追加:
+  1. `validate-inputs` — `run: bash "${{ github.action_path }}/scripts/_libs/validate-inputs.lib.sh"` + env
+  2. `check-existing-repo` — `run: bash "${{ github.action_path }}/scripts/_libs/check-existing.lib.sh"` + env、`id:` を付与
+  3. `actions/setup-node` — `uses:` + `with: node-version: ${{ inputs.node-version }}`
+  4. `pnpm/action-setup` — `uses:` + `with: version: ${{ inputs.pnpm-version }}`
+  5. `actions/checkout` — `uses:` + `with: repository/path/ref` を inputs から渡す
+  6. `validate-repo-structure` — `run: bash` + env + `if: steps.check-existing-repo.outputs.skip != 'true'`
+  7. `pnpm install --frozen-lockfile` — `run: pnpm install --frozen-lockfile` + `working-directory` + `if: steps.check-existing-repo.outputs.skip != 'true'`
+  8. `verify-and-add-path` — `run: bash` + env（`SKIP_REPO` / `REPO` / `PATH_DIR`）
+- 各外部アクションはコミット SHA でピン留め（`# vX.Y.Z` コメント付き）
+
+#### Commit 11: test(setup-tool-repo): add integration test for action.yml
+
+- `scripts/__tests__/integration/setup-tool-repo.integration.spec.sh` を新規作成
+- 正常系: 全スクリプトが連続して pass する統合確認（モック環境）
+- 異常系: `validate-inputs` 失敗時に後続スクリプトが呼ばれないことを確認
+- 異常系: `check-existing` で repo コンフリクト時に exit 1
+
+#### Commit 12: ci(setup-tool-repo): add actionlint and ghalint validation
+
+- `actionlint -config-file ./configs/actionlint.yaml .github/actions/setup-tool-repo/action.yml` が通ることを確認
+- `ghalint run --config ./configs/ghalint.yaml` が通ることを確認
+- 検証エラーがあれば `action.yml` を修正する
+
+---
+
+## 3. Technical Notes
+
+### ライブラリ規約（既存 setup-tool に準拠）
+
+- `set -euo pipefail` をすべてのスクリプトおよびライブラリ（`_libs/*.lib.sh`）の先頭に**必ず**記載する（HARDEN-03）
+- double-source guard（`[ -n "${LIB_LOADED:-}" ] && return 0`）
+- エラー出力: `echo "::error::<message>" >&2`
+- 正常出力: `echo "✓ <message>"`
+
+### GITHUB_PATH / GITHUB_OUTPUT への書き込み（HARDEN-01）
+
+`GITHUB_OUTPUT` および `GITHUB_PATH` への書き込みを行うすべてのスクリプトは、
+書き込み前に `:?` 演算子で未設定チェックを**必ず**実施しなければならない。
+`:-/dev/null` フォールバックは**使用禁止**とする。
+
+```bash
+echo "<path>/bin" >> "${GITHUB_PATH:?GITHUB_PATH is not set}"
+echo "skip=true" >> "${GITHUB_OUTPUT:?GITHUB_OUTPUT is not set}"
+```
+
+対象スクリプト:
+
+- `check-existing.lib.sh`（`GITHUB_OUTPUT` に skip フラグ、`GITHUB_ENV` に `REPO_LOCK_DIR` を書き込む）
+- `verify-and-add-path.lib.sh`（`GITHUB_PATH` に `${PATH_DIR}/bin/` を追記する）
+
+**テスト環境での対応（HARDEN-01）**: ShellSpec ユニットテストでは `GITHUB_OUTPUT`・`GITHUB_PATH` が未設定のため、
+`BeforeEach` で `mktemp` を使って一時ファイルを作成しこれらの変数に設定する。
+
+```bash
+BeforeEach '
+  _tmp_output=$(mktemp)
+  _tmp_path=$(mktemp)
+  _tmp_env=$(mktemp)
+  export GITHUB_OUTPUT="$_tmp_output"
+  export GITHUB_PATH="$_tmp_path"
+  export GITHUB_ENV="$_tmp_env"
+'
+AfterEach 'rm -f "$_tmp_output" "$_tmp_path" "$_tmp_env"'
+```
+
+### .repo ファイル形式
+
+```bash
+<owner>/<repo>@<commit-sha>
+```
+
+- `<commit-sha>`: `git -C <path> rev-parse HEAD` で取得した 40 文字の SHA
+- `check-existing.sh` は `@` より前の部分（`<owner>/<repo>`）のみを入力 `repo` と比較する
+- `verify-and-add-path.sh` が全ステップ成功後に書き込む（skip=true の場合はスキップ）
+
+**書き込みは原子的に行わなければならない（HARDEN-04）**:
+`echo` による直接書き込みは禁止。`mktemp` で一時ファイルに書き込み、`mv` でアトミックに置換する。
+
+```bash
+_tmp=$(mktemp)
+echo "${REPO}@${_sha}" > "$_tmp"
+mv "$_tmp" "${PATH_DIR}/.repo"
+```
+
+### 外部アクションのピン留め（HARDEN-02）
+
+`action.yml` で使用するすべての外部アクションは、バージョンタグではなく**コミット SHA でピン留めしなければならない**。
+バージョンタグのみ（例: `@v4`）の参照は禁止する。
+
+```yaml
+# 正しい例
+uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+
+# 禁止例
+uses: actions/setup-node@v6
+```
+
+適用対象: `actions/setup-node`、`pnpm/action-setup`、`actions/checkout`
+
+### 楽観的ロック設計
+
+同一 `path` への並列実行を防ぐため、`check-existing.sh` 開始時に `mkdir` によるディレクトリロックを取得する。
+
+```text
+check-existing.sh
+  mkdir <path>/.repo.lock   ← アトミック取得（失敗なら exit 1）
+  echo "REPO_LOCK_DIR=..." >> $GITHUB_ENV   ← verify-and-add-path.sh に引き継ぎ
+  [.repo 確認 → skip フラグ出力]
+
+[中間ステップ: setup-node / pnpm / checkout / validate / install]
+
+verify-and-add-path.sh
+  [検証 → GITHUB_PATH 追記 → .repo 書き込み]
+  rmdir "${REPO_LOCK_DIR}"   ← ロック解放
+```
+
+**ロックが解放されないケース**: `verify-and-add-path.sh` が失敗した場合、`.repo.lock` は残存する。
+これは意図的な設計であり、壊れた状態の `path` への後続アクセスを防ぐ。
+手動復旧が必要な場合は `rmdir <path>/.repo.lock` を実行する。
+
+### skip フラグの伝播
+
+`check-existing.lib.sh` が `GITHUB_OUTPUT` に `skip=true/false` を書き込み、
+`action.yml` の後続ステップが `if: steps.check-existing-repo.outputs.skip != 'true'` で参照する。
+
+---
+
+## 4. Change History
+
+| Date       | Version | Description                                                                                                                                                 |
+| ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-06-18 | 1.0.0   | Initial implementation plan                                                                                                                                 |
+| 2026-06-18 | 1.0.1   | Codex review 反映: .repo を owner/repo@sha 形式に変更、permissions削除、GITHUB_OUTPUT/PATH の :? 検証に変更                                                 |
+| 2026-06-18 | 1.0.2   | review explore 反映: Commit 5 に GITHUB_OUTPUT モック設定を追記、Commit 6 に skip フラグ不要の注記追加、Commit 12 を actionlint/ghalint 検証に変更          |
+| 2026-06-18 | 1.0.3   | review harden 反映: HARDEN-01〜04 を SHALL として昇格（:? 検証必須、SHA ピン留め必須、set -euo pipefail 全ライブラリ必須、.repo 原子的書き込み必須）        |
+| 2026-06-18 | 1.0.4   | 楽観的ロック設計追加: check-existing.sh で mkdir によるロック取得、GITHUB_ENV 経由で verify-and-add-path.sh にロック解放を委譲                              |
+| 2026-06-18 | 1.0.5   | review fix: Commit タイトルのファイル名を .lib.sh に統一、HARDEN-01 対象に GITHUB_ENV 追加、Commit 5/Technical Notes の BeforeEach に GITHUB_ENV モック追加 |

--- a/docs/.deckrd/composite-action/setup-tool-repo/requirements/requirements.md
+++ b/docs/.deckrd/composite-action/setup-tool-repo/requirements/requirements.md
@@ -1,0 +1,363 @@
+---
+title: "Requirements: setup-tool-repo Composite Action"
+module: "composite-action/setup-tool-repo"
+status: Draft
+version: 1.0.5
+created: "2026-06-18"
+updated: "2026-06-18"
+---
+
+> **Normative Statement**
+> This document defines binding requirements.
+> Implementations MUST conform to this document.
+> RFC 2119 keywords apply to this document only.
+
+## 1. Overview
+
+### 1.1 Purpose
+
+GitHub Actions ワークフロー内で、Node.js ベースのツール管理リポジトリ（例: `aglabo/agla-doc-tools`）を
+指定ディレクトリにチェックアウトし、依存パッケージをインストールして、ツール群を後続ステップから
+実行可能にするコンポジットアクションを提供する。
+
+### 1.2 Scope
+
+- パブリック GitHub リポジトリを指定ディレクトリに指定 ref でチェックアウトする
+- Node.js および pnpm のセットアップをアクション内で実施する（バージョンは入力パラメータで指定可能）
+- `pnpm install --frozen-lockfile` で依存パッケージをインストールする（pnpm 固定）
+- リポジトリの `bin/` ディレクトリを `$GITHUB_PATH` に追加し、後続ステップからツールを実行可能にする
+- post-install で `bin/` と `node_modules/.bin/` の存在および `bin/` の実行権限を検証する
+
+**Out of Scope**:
+
+- プライベートリポジトリへのアクセス（認証トークンは使用しない）
+- macOS / Windows ランナーのサポート（Linux ubuntu runner のみ）
+- チェックサム検証やセキュリティスキャン（呼び出し元ワークフロー側の責務）
+- npm / yarn など pnpm 以外のパッケージマネージャーのサポート
+- インストールキャッシュの提供（呼び出し元ワークフロー側の責務）
+
+## 2. Context
+
+- Target Environment: GitHub Actions ubuntu runner（Linux x86_64）
+- Related Components:
+  - `actions/checkout` — リポジトリチェックアウト
+  - `actions/setup-node` — Node.js セットアップ
+  - `pnpm/action-setup` — pnpm セットアップ
+  - 既存コンポジットアクション `composite-action/setup-tool` — GitHub Releases からバイナリを取得する別アクション
+- Assumptions:
+  - 呼び出し元リポジトリは既にチェックアウト済みである
+  - ツールリポジトリはパブリックリポジトリであり、デフォルトの `GITHUB_TOKEN` でアクセス可能である
+  - ツールリポジトリは `package.json` および `pnpm-lock.yaml` をリポジトリルートに持つ
+  - ツールリポジトリのルートに `bin/` ディレクトリが存在し、`node_modules/.bin` を内部で呼び出すラッパースクリプトが配置されている
+  - `ref` には不変な参照（コミット SHA またはタグ）を指定することを推奨する（サプライチェーンリスク軽減）
+  - `path` は `GITHUB_WORKSPACE` 配下の未使用ディレクトリを指定する
+
+### System Context Diagram
+
+```text
+[GitHub Actions Workflow] --> +------------------------------------------+
+                              |  setup-tool-repo Composite Action         |
+[External Tool Repo] -------> |  1. actions/setup-node (node-version)     |
+(public GitHub repo,          |  2. pnpm/action-setup (pnpm-version)      |
+ e.g. aglabo/agla-doc-tools)  |  3. actions/checkout (repo, path, ref)    |
+                              |  4. pnpm install --frozen-lockfile         |
+                              |  5. verify bin/ + node_modules/.bin/       |
+                              |  6. add <path>/bin/ to GITHUB_PATH         |
+                              +------------------------------------------+
+                                              |
+                                             \|/
+                              [Subsequent Steps: run tools via bin/]
+```
+
+## 3. Design Decisions (Summary)
+
+| ID    | Decision                                                                              | Linked Record            |
+| ----- | ------------------------------------------------------------------------------------- | ------------------------ |
+| DR-01 | パブリックリポジトリのみ対応                                                          | decision-record.md#DR-01 |
+| DR-02 | パッケージマネージャーは pnpm 固定                                                    | decision-record.md#DR-02 |
+| DR-03 | Node.js / pnpm セットアップはアクション内で実施                                       | decision-record.md#DR-03 |
+| DR-04 | PATH に追加するのは `bin/` のみ                                                       | decision-record.md#DR-04 |
+| DR-05 | `ref` は必須パラメータとする                                                          | decision-record.md#DR-05 |
+| DR-06 | Node.js / pnpm バージョンは入力パラメータで指定可能、デフォルト値をアクション側で定義 | decision-record.md#DR-06 |
+
+## 4. Functional Requirements
+
+### REQ-F-001: 外部リポジトリのチェックアウト
+
+- EARS Type: event-driven
+
+```text
+GIVEN GitHub Actions ワークフローが setup-tool-repo アクションを呼び出した
+  WHEN 入力パラメータ repo（owner/repo 形式）、path（チェックアウト先ディレクトリ）、
+       ref（ブランチ/タグ/コミット SHA）がすべて指定された
+THEN the system SHALL 指定した ref で外部リポジトリを指定パスにチェックアウトする。
+```
+
+**Rationale**: `ref` を必須にすることで、デフォルトブランチの予期しない変更による
+サプライチェーンリスクを防ぐ。コミット SHA の使用を推奨する。
+
+**Acceptance Criteria**:
+
+| AC ID  | Scenario                                                                      |
+| ------ | ----------------------------------------------------------------------------- |
+| AC-001 | 有効な repo・path・ref を指定した場合、指定ディレクトリにチェックアウトされる |
+| AC-002 | ref にコミット SHA を指定した場合、そのコミットがチェックアウトされる         |
+| AC-003 | ref を省略した場合、アクションがエラーで失敗する                              |
+
+### REQ-F-002: pnpm によるパッケージインストール
+
+- EARS Type: feature/config-based
+
+```text
+GIVEN チェックアウトが完了した
+  WHERE チェックアウト先ディレクトリに pnpm-lock.yaml が存在する
+THEN the system SHALL pnpm install --frozen-lockfile を実行して依存パッケージをインストールする。
+```
+
+```text
+GIVEN チェックアウトが完了した
+  WHERE チェックアウト先ディレクトリに pnpm-lock.yaml が存在しない
+THEN the system SHALL エラーメッセージを出力してアクションを失敗させる。
+```
+
+**Rationale**: パッケージマネージャーを pnpm に固定することで、ツールリポジトリの設計を
+明確化する。`--frozen-lockfile` により lock ファイルとの整合性を保証し再現性を確保する。
+`pnpm-lock.yaml` がない場合はリポジトリの設定ミスとみなしてフェイルファーストする。
+
+**Acceptance Criteria**:
+
+| AC ID  | Scenario                                                                      |
+| ------ | ----------------------------------------------------------------------------- |
+| AC-004 | pnpm-lock.yaml が存在する場合、pnpm install --frozen-lockfile が実行される    |
+| AC-005 | pnpm-lock.yaml が存在しない場合、エラーメッセージとともにアクションが失敗する |
+
+### REQ-F-003: インストール後の検証
+
+- EARS Type: event-driven
+
+```text
+GIVEN パッケージのインストールが完了した
+  WHEN インストール後の post-install 検証フェーズが実行された
+THEN the system SHALL 以下をすべて確認し、いずれかが失敗した場合はエラーを出力して
+     アクションを失敗させる:
+     (1) <path>/bin/ ディレクトリが存在する
+     (2) <path>/node_modules/.bin/ ディレクトリが存在する
+     (3) <path>/bin/ 配下のすべてのファイルが実行権限（executable bit）を持つ
+```
+
+**Rationale**: `bin/` と `node_modules/.bin` の両方が揃って初めてツールが実行できる。
+また実行権限がないラッパースクリプトはシェルから直接呼び出せないため、早期検証で
+デプロイ後の実行失敗を防ぐ。
+
+**Acceptance Criteria**:
+
+| AC ID  | Scenario                                                                                |
+| ------ | --------------------------------------------------------------------------------------- |
+| AC-006 | bin/ と node_modules/.bin が両方存在し、bin/ 内ファイルに実行権限がある場合は続行される |
+| AC-007 | node_modules/.bin が存在しない場合、エラーメッセージとともにアクションが失敗する        |
+| AC-013 | bin/ が存在しない場合、エラーメッセージとともにアクションが失敗する                     |
+| AC-014 | bin/ 配下のファイルに実行権限がない場合、エラーメッセージとともにアクションが失敗する   |
+
+### REQ-F-004: bin/ ディレクトリの PATH 追加
+
+- EARS Type: event-driven
+
+```text
+GIVEN bin/・node_modules/.bin/ の存在確認および bin/ の実行権限検証がすべて成功した
+  WHEN アクションの PATH 追加フェーズが実行された
+THEN the system SHALL チェックアウト先ディレクトリの bin/ を $GITHUB_PATH に追加し、
+     後続ステップからツールが実行可能な状態にする。
+```
+
+**Rationale**: `bin/` 配下のラッパースクリプトを後続ステップのシェルから直接呼び出せるようにする。
+`node_modules/.bin` は `bin/` が内部的に解決するため、PATH 追加は `bin/` のみとする。
+
+**Acceptance Criteria**:
+
+| AC ID  | Scenario                                                           |
+| ------ | ------------------------------------------------------------------ |
+| AC-008 | アクション完了後、後続ステップで bin/ 配下のツールが実行可能になる |
+| AC-009 | $GITHUB_PATH に bin/ の絶対パスが追加されている                    |
+
+### REQ-F-005: Node.js および pnpm のセットアップ
+
+- EARS Type: event-driven
+
+```text
+GIVEN setup-tool-repo アクションが開始した
+  WHEN チェックアウトおよびインストールの前に環境セットアップフェーズが実行された
+THEN the system SHALL actions/setup-node で Node.js を、pnpm/action-setup で pnpm を
+     セットアップする。入力パラメータ node-version および pnpm-version でバージョンを
+     指定できるものとし、未指定時はアクション側で定義したデフォルト値を使用する。
+```
+
+**Rationale**: ランナーに pnpm がデフォルトでインストールされていない環境を想定し、
+アクション内で pnpm のセットアップを保証する。バージョンを入力パラメータ化することで
+呼び出し元が将来バージョンを固定できる柔軟性を持たせる。
+
+**Acceptance Criteria**:
+
+| AC ID  | Scenario                                                                          |
+| ------ | --------------------------------------------------------------------------------- |
+| AC-010 | アクション実行後、指定した pnpm バージョンのコマンドが利用可能になっている        |
+| AC-011 | アクション実行後、指定した Node.js バージョンが利用可能になっている               |
+| AC-012 | node-version・pnpm-version を省略した場合、アクション定義のデフォルト値が使われる |
+
+## 5. Non-Functional Requirements
+
+### REQ-NF-001: 再現性
+
+インストールは `pnpm install --frozen-lockfile` を使用すること。
+lock ファイルとの整合性が取れない場合はインストールを失敗させること。
+
+### REQ-NF-002: 最小権限
+
+アクションに必要な GitHub Actions permissions は `contents: read` のみとする。
+`id-token: write` や `contents: write` を追加してはならない。
+
+### REQ-NF-003: Fail-fast
+
+各フェーズ（チェックアウト・インストール・検証）が失敗した場合、後続フェーズを実行せず
+即座に明確なエラーメッセージとともにアクションを終了させること。
+
+### REQ-NF-004: 保守性
+
+スクリプトは既存の `composite-action/setup-tool` のライブラリ規約（`set -euo pipefail`、
+double-source guard、フェーズ別 exit code）に準拠すること。
+
+## 6. Constraints
+
+### REQ-C-001: Linux ubuntu runner のみ対応
+
+本アクションは GitHub Actions の ubuntu runner（Linux x86_64）のみを対象とする。
+macOS および Windows ランナーはサポートしない。
+
+### REQ-C-002: パブリックリポジトリのみ
+
+認証トークンの入力パラメータは提供しない。プライベートリポジトリへのアクセスは対象外とする。
+呼び出し元がプライベートリポジトリを使用する場合は、別途アクションを作成すること。
+
+### REQ-C-003: bin/ ディレクトリの存在が前提
+
+ツールリポジトリのルートに `bin/` ディレクトリが存在することを前提とする。
+`bin/` が存在しない場合はエラーを出力してアクションを失敗させる。
+
+### REQ-C-004: pnpm-lock.yaml の存在が前提
+
+ツールリポジトリのルートに `pnpm-lock.yaml` が存在することを前提とする。
+存在しない場合はリポジトリの設定ミスとみなしてアクションを失敗させる。
+
+### REQ-C-005: repo パラメータのフォーマット
+
+`repo` パラメータは `<owner>/<repo>` 形式（英数字・ハイフン・アンダースコア、スラッシュ1つ）でなければならない。
+フォーマットが不正な場合はエラーを出力してアクションを失敗させる。
+
+### REQ-C-006: path パラメータのフォーマット
+
+`path` パラメータは `./` で始まる相対パス、または `/` で始まる絶対パスのいずれかでなければならない。
+それ以外の形式（例: `tools/agla`、`../foo`）はエラーを出力してアクションを失敗させる。
+
+## 7. User Stories
+
+| Story ID | Role             | Goal                                                    | Reason                                                      | Related Requirements  |
+| -------- | ---------------- | ------------------------------------------------------- | ----------------------------------------------------------- | --------------------- |
+| US-001   | ワークフロー作者 | ツールリポジトリを1ステップでセットアップしたい         | ワークフローの記述量を削減するため                          | REQ-F-001, REQ-F-002  |
+| US-002   | ワークフロー作者 | 特定バージョンのツールリポジトリを固定して使いたい      | CI の再現性を保証するため                                   | REQ-F-001             |
+| US-003   | ワークフロー作者 | インストール後に即座にツールを呼び出したい              | 追加の PATH 設定なしにツールを使いたいため                  | REQ-F-004             |
+| US-004   | CI メンテナー    | pnpm ベースのツールリポジトリを確実にセットアップしたい | pnpm-lock.yaml による再現性の高いインストールを保証するため | REQ-F-002, REQ-NF-001 |
+| US-005   | CI メンテナー    | インストール失敗を早期に検知したい                      | デバッグ時間を削減するため                                  | REQ-F-003, REQ-NF-003 |
+
+## 8. Acceptance Criteria
+
+```gherkin
+# AC-001: 有効な repo と path を指定してチェックアウトが成功する
+# Requirement: REQ-F-001
+Scenario: 有効な repo と path を指定してチェックアウトが成功する
+  Given GitHub Actions ワークフローが setup-tool-repo アクションを呼び出す
+  When repo="aglabo/agla-doc-tools" path="./tools/agla" ref="v1.0.0" を入力として渡す
+  Then "./tools/agla" ディレクトリにリポジトリがチェックアウトされる
+
+# AC-002: ref を指定した場合に特定バージョンがチェックアウトされる
+# Requirement: REQ-F-001
+Scenario: ref を指定して特定タグがチェックアウトされる
+  Given setup-tool-repo アクションを呼び出す
+  When repo="aglabo/agla-doc-tools" path="./tools/agla" ref="v1.2.3" を渡す
+  Then "./tools/agla" に v1.2.3 タグのコードがチェックアウトされる
+
+# AC-004: pnpm-lock.yaml が存在する場合 pnpm install が実行される
+# Requirement: REQ-F-002
+Scenario: pnpm-lock.yaml があるリポジトリで pnpm install が実行される
+  Given チェックアウト先に pnpm-lock.yaml が存在する
+  When インストールフェーズが実行される
+  Then pnpm install が実行されて node_modules が作成される
+
+# AC-007: node_modules/.bin が存在しない場合アクションが失敗する
+# Requirement: REQ-F-003
+Scenario: node_modules/.bin が存在しない場合アクションが失敗する
+  Given インストールが完了したが node_modules/.bin が存在しない
+  When post-install 検証フェーズが実行される
+  Then アクションがエラーメッセージとともに非ゼロ exit code で終了する
+
+# AC-008: アクション完了後に後続ステップでツールが実行可能になる
+# Requirement: REQ-F-004
+Scenario: bin/ が PATH に追加されてツールが実行可能になる
+  Given setup-tool-repo アクションが正常に完了した
+  When 後続ステップでツール名をコマンドとして実行する
+  Then ツールが正常に起動する
+
+# AC-015: repo が不正フォーマットの場合アクションが失敗する
+# Requirement: REQ-C-005
+Scenario: repo に owner/repo 形式でない値を指定した場合アクションが失敗する
+  Given setup-tool-repo アクションを呼び出す
+  When repo="agla-doc-tools"（スラッシュなし）を渡す
+  Then アクションがエラーメッセージとともに非ゼロ exit code で終了する
+
+# AC-016: path が不正フォーマットの場合アクションが失敗する
+# Requirement: REQ-C-006
+Scenario: path に ./ でも / でも始まらない値を指定した場合アクションが失敗する
+  Given setup-tool-repo アクションを呼び出す
+  When path="tools/agla"（./ も / も始まらない）を渡す
+  Then アクションがエラーメッセージとともに非ゼロ exit code で終了する
+```
+
+## 9. Open Questions
+
+| Question                                                                                      | Type   | Impact Area          | Owner | Status    |
+| --------------------------------------------------------------------------------------------- | ------ | -------------------- | ----- | --------- |
+| OQ-001: bin/ が存在しない場合エラーにするか → **エラーで失敗させる**                          | Design | REQ-F-004, REQ-C-003 | —     | ✅ Closed |
+| OQ-002: Node.js バージョンを入力パラメータで指定できるようにするか → **可能、デフォルトあり** | Scope  | REQ-F-005            | —     | ✅ Closed |
+| OQ-003: pnpm バージョンを入力パラメータで指定できるようにするか → **可能、デフォルトあり**    | Scope  | REQ-F-005            | —     | ✅ Closed |
+| OQ-004: インストール時のキャッシュ（actions/cache）をアクション内で提供するか                 | Scope  | REQ-NF-001           | TBD   | Open      |
+| OQ-005: pnpm install --frozen-lockfile は必須か → **必須（固定）**                            | Design | REQ-NF-001           | —     | ✅ Closed |
+| OQ-006: `ref` 未指定時の挙動 → **エラーで失敗させる（ref は必須）**                           | Design | REQ-F-001            | —     | ✅ Closed |
+
+## 10. Traceability
+
+| REQ ID     | AC IDs                         | Type           |
+| ---------- | ------------------------------ | -------------- |
+| REQ-F-001  | AC-001, AC-002, AC-003         | Functional     |
+| REQ-F-002  | AC-004, AC-005                 | Functional     |
+| REQ-F-003  | AC-006, AC-007, AC-013, AC-014 | Functional     |
+| REQ-F-004  | AC-008, AC-009                 | Functional     |
+| REQ-F-005  | AC-010, AC-011, AC-012         | Functional     |
+| REQ-NF-001 | N/A                            | Non-Functional |
+| REQ-NF-002 | N/A                            | Non-Functional |
+| REQ-NF-003 | N/A                            | Non-Functional |
+| REQ-NF-004 | N/A                            | Non-Functional |
+| REQ-C-001  | N/A                            | Constraint     |
+| REQ-C-002  | N/A                            | Constraint     |
+| REQ-C-003  | N/A                            | Constraint     |
+| REQ-C-004  | N/A                            | Constraint     |
+| REQ-C-005  | AC-015                         | Constraint     |
+| REQ-C-006  | AC-016                         | Constraint     |
+
+## 11. Change History
+
+| Date       | Version | Description                                                                                |
+| ---------- | ------- | ------------------------------------------------------------------------------------------ |
+| 2026-06-18 | 1.0.0   | Initial release                                                                            |
+| 2026-06-18 | 1.0.1   | ref 必須化、pnpm 固定、Node.js/pnpm バージョンパラメータ化（Codex review 反映）            |
+| 2026-06-18 | 1.0.2   | REQ-F-003 拡張: bin/ 存在確認・node_modules/.bin 存在確認・実行権限チェックを追加          |
+| 2026-06-18 | 1.0.3   | review explore 反映: Section 1.2・図・US-004 を pnpm 固定設計に整合                        |
+| 2026-06-18 | 1.0.4   | REQ-C-005 追加: repo は owner/repo 形式必須、REQ-C-006 追加: path は ./ または絶対パス必須 |
+| 2026-06-18 | 1.0.5   | review explore 反映: AC-001/002 の path 修正、REQ-F-004 GIVEN 更新、AC-015/016 追加        |

--- a/docs/.deckrd/composite-action/setup-tool-repo/specifications/specifications.md
+++ b/docs/.deckrd/composite-action/setup-tool-repo/specifications/specifications.md
@@ -1,0 +1,388 @@
+---
+title: "Design Specification: setup-tool-repo Composite Action"
+based-on: requirements.md v1.0.5
+status: Draft
+version: 1.0.2
+created: "2026-06-18"
+---
+
+> **Normative Statement**
+> This document defines behavioral contracts for implementation.
+> RFC 2119 keywords apply to this document only.
+
+## 1. Overview
+
+### 1.1 Purpose
+
+`setup-tool-repo` コンポジットアクションの外部動作契約を定義する。
+GitHub Actions ワークフローが Node.js ベースのツール管理リポジトリを
+チェックアウト・インストールし、後続ステップからツールを実行可能にするまでの
+各ユニットの事前条件・事後条件・エラー規則を規定する。
+
+### 1.2 Scope
+
+本仕様書は各ユニットの **振る舞いルール** と **外部インターフェース契約** を定義する。
+
+実装の詳細（関数名・ファイルパス・クラス構造）は明示的にスコープ外とする。
+
+---
+
+## 2. Design Principles
+
+### 2.1 Design Philosophy
+
+- **Fail-fast**: 各ユニットは事前条件が満たされない場合、後続処理を実行せず即座に失敗する
+- **順序保証**: 6 ユニットは定義された順序で実行され、前ユニットの成功が次ユニットの事前条件となる
+- **最小副作用**: 副作用（GITHUB_PATH への書き込み）は最終ユニット（add-path）のみに集約する
+- **公式アクション委譲**: Node.js / pnpm のセットアップとリポジトリチェックアウトは公式アクションに委譲する
+
+### 2.2 Design Assumptions
+
+- 呼び出し元リポジトリは既にチェックアウト済みである
+- ツールリポジトリはパブリックリポジトリであり、デフォルト `GITHUB_TOKEN` でアクセス可能
+- ツールリポジトリのルートに `package.json`、`pnpm-lock.yaml`、`bin/` が存在する
+- `bin/` 配下のラッパースクリプトは `node_modules/.bin` を内部で解決する
+- ランナーは GitHub Actions の ubuntu runner（Linux x86_64）である
+
+### 2.3 External Design Summary
+
+> **Source**: Phase D（ユーザー確認済み設計方向）および Phase E（外部設計対話）より導出。
+
+#### Feature Decomposition
+
+| Unit                | Responsibility                                                  | REQ Coverage             |
+| ------------------- | --------------------------------------------------------------- | ------------------------ |
+| validate-inputs     | repo / path / ref の入力検証                                    | REQ-F-001, REQ-C-005/006 |
+| check-existing-repo | path の既存チェックアウト確認（.repo ファイルによる同一性検証） | REQ-F-001                |
+| setup-environment   | Node.js / pnpm のセットアップ                                   | REQ-F-005                |
+| checkout-repo       | 外部リポジトリのチェックアウトと .repo ファイルの作成           | REQ-F-001                |
+| validate-env        | Linux/GitHub-hosted runner の確認、checkout 後の repo 構造検証  | REQ-C-001, REQ-C-003/004 |
+| install-packages    | pnpm install --frozen-lockfile                                  | REQ-F-002                |
+| verify-install      | bin/ + node_modules/.bin/ 存在・実行権限検証                    | REQ-F-003, REQ-C-003     |
+| add-path            | bin/ を GITHUB_PATH に追加                                      | REQ-F-004                |
+
+#### Unit Interaction Map
+
+```text
++------------------+     +----------------------+
+| validate-inputs  | --> | check-existing-repo  |
++------------------+     +----------------------+
+                            |              |
+                     same repo        different repo
+                     (skip flag)          |
+                            |             v
+                            |          [exit 1]
+                            v
+                   +-------------------+
+                   | setup-environment |
+                   +-------------------+
+                            |
+                            v
+                   +----------------+     (skip flag set)
+                   | checkout-repo  | --> [skip: write .repo skipped]
+                   +----------------+
+                            |
+                            v
+                   +------------------+
+                   |  validate-env    |
+                   +------------------+
+                            |
+                            v
+                   +------------------+
+                   | install-packages |
+                   +------------------+
+                            |
+                            v
+                   +------------------+
+                   | verify-install   |
+                   +------------------+
+                            |
+                            v
+                   +------------------+
+                   |   add-path       |
+                   +------------------+
+                            |
+                            v
+               [Subsequent Steps: tools available]
+```
+
+#### Data Flow Diagram
+
+```text
+[inputs: repo, path, ref, node-version, pnpm-version]
+           |
+           v
+[validate-inputs] --fail--> [exit 1: invalid format]
+           |
+           v
+[check-existing-repo]
+  <path> exists?
+  |              |
+  | yes          | no (new checkout)
+  v              |
+[read .repo]     |
+  |              |
+  same repo? --> skip flag = true
+  |
+  different repo --> [exit 1: repo conflict]
+           |
+           v (skip flag = false, or new)
+[setup-environment: setup-node + pnpm/action-setup]
+           |
+           v
+[checkout-repo: actions/checkout + write .repo] --fail--> [exit propagated]
+  (skipped if skip flag = true)
+           |
+           v
+[validate-env: runner OS + pnpm-lock.yaml + bin/ 存在確認]
+  |                   |
+  | fail              | success
+  v                   v
+[exit 1]   [install-packages: pnpm install --frozen-lockfile]
+             |         |
+             | fail    | success
+             v         v
+          [exit 1]  [verify-install]
+                       |         |
+                       | fail    | success
+                       v         v
+                    [exit 1]  [add-path]
+                              1. echo >> GITHUB_PATH
+                              2. write .repo (skip if skip flag = true)
+                           --> exit 0
+```
+
+### 2.4 Non-Goals
+
+> **Derivation**: requirements.md Section 1.2 Out of Scope より。
+
+- プライベートリポジトリへのアクセス ← REQ-C-002
+- macOS / Windows ランナーのサポート ← REQ-C-001
+- チェックサム検証やセキュリティスキャン（呼び出し元責務）
+- npm / yarn など pnpm 以外のパッケージマネージャーのサポート
+- インストールキャッシュの提供（呼び出し元責務）
+
+### 2.5 Behavioral Design Decisions
+
+| ID    | Decision                                                        | Rationale                                        | Affected Rules | Status |
+| ----- | --------------------------------------------------------------- | ------------------------------------------------ | -------------- | ------ |
+| DD-01 | `ref` は必須パラメータとする                                    | サプライチェーンリスク軽減（DR-05）              | R-003          | Active |
+| DD-02 | パッケージマネージャーは pnpm 固定                              | ツールリポジトリ設計の明確化（DR-02）            | R-007, R-008   | Active |
+| DD-03 | Node.js デフォルト `"22"`、pnpm デフォルト `"10"`               | プロジェクト既存実績値に準拠                     | R-005, R-006   | Active |
+| DD-04 | PATH 追加は `bin/` のみ（`node_modules/.bin` は追加しない）     | `bin/` が内部解決するため二重追加は不要（DR-04） | R-013          | Active |
+| DD-05 | `path` はセグメント単位で `..` を検出（部分文字列マッチは不可） | パストラバーサル防止・誤検知回避                 | R-002          | Active |
+| DD-06 | `path` は `./` 始まりの相対パスのみ（絶対パス不可）             | actions/checkout との整合性確保                  | R-002          | Active |
+| DD-07 | Linux/GitHub-hosted runner の確認は validate-env ユニットで実施 | 既存 validate-environment アクションと責務を統一 | R-010          | Active |
+
+### 2.6 Related Decision Records
+
+| DR-ID | Title                              | Phase | Impact on This Spec                   |
+| ----- | ---------------------------------- | ----- | ------------------------------------- |
+| DR-02 | パッケージマネージャーは pnpm 固定 | req   | install-packages ユニットの動作を規定 |
+| DR-04 | PATH に追加するのは `bin/` のみ    | req   | add-path ユニットの副作用を限定       |
+| DR-05 | `ref` は必須パラメータ             | req   | validate-inputs の必須チェックを規定  |
+
+### 2.7 DD to DR Promotion Criteria
+
+DD-01〜DD-05 は本仕様ローカルな決定であり、現状 DR 昇格の必要はない。
+ただし DD-03（バージョンデフォルト値）は将来バージョン変更時に影響範囲が広いため、
+プロジェクト横断的な変更が生じた場合は DR 昇格を検討する。
+
+---
+
+## 3. Behavioral Specification
+
+### 3.1 Input Domain
+
+| Parameter      | Required | Format                                                            | Default |
+| -------------- | -------- | ----------------------------------------------------------------- | ------- |
+| `repo`         | Yes      | `<owner>/<repo>` 形式（英数字・ハイフン・アンダースコア・ドット） | —       |
+| `path`         | Yes      | `./` で始まる相対パス。`..` セグメントを含まない                  | —       |
+| `ref`          | Yes      | ブランチ名・タグ名・コミット SHA（非空文字列）                    | —       |
+| `node-version` | No       | 任意の Node.js バージョン文字列                                   | `"22"`  |
+| `pnpm-version` | No       | 任意の pnpm バージョン文字列                                      | `"10"`  |
+
+#### repo フォーマット規則
+
+- `owner` 部: 英字始まり、英数字・ハイフン、最大 39 文字
+- `repo` 部: 英数字・ハイフン・アンダースコア・ドット、最大 100 文字
+- スラッシュはちょうど 1 つ
+
+#### path フォーマット規則
+
+- `./` で始まる相対パスのみ許可（例: `./tools/agla`）
+- 絶対パス（`/` 始まり）は不可
+- `..` セグメントを含んではならない
+  - セグメント単位で判定: パスを `/` で分割し、いずれかのセグメントが `..` と等しい場合は不正
+  - 例: `./foo/../bar`（不正）、`./foo..bar`（正当 — `..` はセグメント全体ではない）
+
+### 3.2 Output Semantics
+
+**成功時（exit 0）:**
+
+- `<path>/bin/` の絶対パスが `GITHUB_PATH` ファイルに追記されている
+- 後続ステップの `PATH` に `<path>/bin/` が含まれる
+
+**失敗時（exit 非ゼロ）:**
+
+- `::error::` プレフィックスのエラーメッセージが stderr に出力される
+- `GITHUB_PATH` への書き込みは行われない
+- 失敗したユニットの exit code が伝播する（exit 1 固定）
+
+---
+
+## 4. Decision Rules
+
+評価は以下の順序で実行しなければならない。順序の変更は禁止する。
+
+### Unit 1: validate-inputs
+
+| Rule ID | Step | Condition                                                       | Outcome             |
+| ------- | ---: | --------------------------------------------------------------- | ------------------- |
+| R-001   |    1 | `repo` が `owner/repo` 形式でない                               | エラー出力 → exit 1 |
+| R-002   |    2 | `path` が `./` で始まらない、またはパスセグメントに `..` を含む | エラー出力 → exit 1 |
+| R-003   |    3 | `ref` が空文字列（空白のみを含む）                              | エラー出力 → exit 1 |
+| R-004   |    4 | 全パラメータが有効                                              | Unit 2 へ進む       |
+
+### Unit 2: check-existing-repo
+
+`<path>` ディレクトリの存在と `.repo` ファイルを確認し、同一リポジトリの再利用またはコンフリクト検出を行う。
+
+| Rule ID | Step | Condition                                         | Outcome                         |
+| ------- | ---: | ------------------------------------------------- | ------------------------------- |
+| R-005   |    1 | `<path>` ディレクトリが存在しない                 | skip フラグ = false → Unit 3 へ |
+| R-006   |    2 | `<path>` が存在するが `<path>/.repo` が存在しない | エラー出力 → exit 1             |
+| R-007   |    3 | `<path>/.repo` の内容が入力 `repo` と一致する     | skip フラグ = true → Unit 3 へ  |
+| R-008   |    4 | `<path>/.repo` の内容が入力 `repo` と異なる       | エラー出力 → exit 1             |
+
+### Unit 3: setup-environment
+
+| Rule ID | Step | Condition                   | Outcome                  |
+| ------- | ---: | --------------------------- | ------------------------ |
+| R-009   |    1 | `node-version` 未指定       | デフォルト `"22"` を使用 |
+| R-010   |    2 | `pnpm-version` 未指定       | デフォルト `"10"` を使用 |
+| R-011   |    3 | `actions/setup-node` が成功 | 次ステップへ進む         |
+| R-011E  |    3 | `actions/setup-node` が失敗 | エラー伝播 → exit 非ゼロ |
+| R-012   |    4 | `pnpm/action-setup` が成功  | Unit 4 へ進む            |
+| R-012E  |    4 | `pnpm/action-setup` が失敗  | エラー伝播 → exit 非ゼロ |
+
+### Unit 4: checkout-repo
+
+skip フラグが true の場合、このユニット全体をスキップする。
+
+| Rule ID | Step | Condition                                  | Outcome                  |
+| ------- | ---: | ------------------------------------------ | ------------------------ |
+| R-013   |    1 | skip フラグ = true                         | Unit 5 へスキップ        |
+| R-014   |    2 | `actions/checkout` が成功                  | Unit 5 へ進む            |
+| R-014E  |    2 | `actions/checkout` が失敗（repo 不存在等） | エラー伝播 → exit 非ゼロ |
+
+### Unit 5: validate-env
+
+checkout 完了後、ランナー環境とリポジトリ構造を検証する。
+
+| Rule ID | Step | Condition                                    | Outcome             |
+| ------- | ---: | -------------------------------------------- | ------------------- |
+| R-010   |    1 | ランナーが Linux/GitHub-hosted runner でない | エラー出力 → exit 1 |
+| R-011   |    2 | `<path>/pnpm-lock.yaml` が存在しない         | エラー出力 → exit 1 |
+| R-012   |    3 | `<path>/bin/` ディレクトリが存在しない       | エラー出力 → exit 1 |
+| R-013   |    4 | 全環境検証通過                               | Unit 5 へ進む       |
+
+### Unit 5: install-packages
+
+| Rule ID | Step | Condition                               | Outcome                  |
+| ------- | ---: | --------------------------------------- | ------------------------ |
+| R-014   |    1 | `pnpm install --frozen-lockfile` が成功 | Unit 6 へ進む            |
+| R-014E  |    1 | `pnpm install --frozen-lockfile` が失敗 | エラー伝播 → exit 非ゼロ |
+
+### Unit 6: verify-install
+
+| Rule ID | Step | Condition                                                 | Outcome                       |
+| ------- | ---: | --------------------------------------------------------- | ----------------------------- |
+| R-015   |    1 | `<path>/node_modules/.bin/` が存在しない                  | エラー出力 → exit 1           |
+| R-016   |    2 | `<path>/bin/` 配下にファイルが存在しない                  | エラー出力 → exit 1           |
+| R-017   |    3 | `<path>/bin/` 配下のファイルに shebang あり・実行権限なし | `chmod +x` を自動適用して続行 |
+| R-017   |    3 | `<path>/bin/` 配下のファイルに shebang なし・実行権限なし | エラー出力 → exit 1           |
+| R-018   |    4 | 全検証通過                                                | Unit 7 へ進む                 |
+
+### Unit 7: add-path
+
+全ステップが成功した後、PATH 追加と `.repo` ファイルの作成を行う。
+
+| Rule ID | Step | Condition                                                    | Outcome             |
+| ------- | ---: | ------------------------------------------------------------ | ------------------- |
+| R-019   |    1 | `<path>/bin/` の絶対パスを `GITHUB_PATH` に追記              | 次ステップへ進む    |
+| R-019E  |    1 | `GITHUB_PATH` への追記が失敗                                 | エラー出力 → exit 1 |
+| R-020   |    2 | skip フラグ = false: `<path>/.repo` に `repo` の値を書き込む | exit 0（成功）      |
+| R-020S  |    2 | skip フラグ = true: `.repo` の書き込みをスキップ             | exit 0（成功）      |
+| R-020E  |    2 | `.repo` ファイルの書き込みが失敗                             | エラー出力 → exit 1 |
+
+---
+
+## 5. Edge Cases
+
+| Input / Situation                              | Outcome            | Rule  | Rationale                                                  |
+| ---------------------------------------------- | ------------------ | ----- | ---------------------------------------------------------- |
+| `repo="agla-doc-tools"`（スラッシュなし）      | exit 1             | R-001 | owner/repo 形式のみ許可                                    |
+| `repo="owner/repo/extra"`（スラッシュ複数）    | exit 1             | R-001 | スラッシュはちょうど 1 つ                                  |
+| `path="tools/agla"`（`./` なし）               | exit 1             | R-002 | `./` で始まる相対パスのみ許可                              |
+| `path="/tmp/tools"`（絶対パス）                | exit 1             | R-002 | 絶対パスは不可、`./` 始まりのみ                            |
+| `path="./foo/../bar"`（`..` セグメントを含む） | exit 1             | R-002 | パストラバーサル防止（セグメント単位で判定）               |
+| `path="./foo..bar"`（`..` がセグメント内部）   | 続行               | R-002 | セグメント全体が `..` でないため正当                       |
+| `path="../outside"`（`..` 始まり）             | exit 1             | R-002 | `./` で始まらない形式                                      |
+| `ref=""`（空文字列）                           | exit 1             | R-003 | ref は必須                                                 |
+| `ref="  "`（空白のみ）                         | exit 1             | R-003 | 空白のみは空文字列と同等                                   |
+| Linux 以外の runner で実行                     | exit 1             | R-010 | validate-env でランナー OS を確認                          |
+| `pnpm-lock.yaml` が存在しない                  | exit 1             | R-011 | pnpm リポジトリのみ対応                                    |
+| checkout 後に `bin/` が存在しない              | exit 1             | R-012 | validate-env でリポジトリ構造を確認                        |
+| `node_modules/.bin/` が空ディレクトリ          | 続行               | R-015 | ディレクトリ存在のみ確認（内容は verify-install の責務外） |
+| `bin/` が空ディレクトリ                        | exit 1             | R-016 | 実行可能ファイルが存在しない                               |
+| `bin/` 配下にシンボリックリンクのみ存在        | 続行（条件付き）   | R-017 | リンク先の shebang を確認し、あれば `chmod +x` を自動適用  |
+| `path` が存在し `.repo` がない                 | exit 1             | R-006 | 管理外ディレクトリとみなして失敗                           |
+| `path` が存在し `.repo` が同一 repo            | スキップ（exit 0） | R-007 | 再チェックアウト不要                                       |
+| `path` が存在し `.repo` が別 repo              | exit 1             | R-008 | repo コンフリクト                                          |
+| `path` が存在しない（新規）                    | 通常フロー         | R-005 | 新規チェックアウト                                         |
+
+---
+
+## 6. Requirements Traceability
+
+| Requirement ID | Spec Rule(s)                             | Notes                                              |
+| -------------- | ---------------------------------------- | -------------------------------------------------- |
+| REQ-F-001      | R-001, R-002, R-003, R-005〜R-008, R-014 | バリデーション・既存チェック・チェックアウトを含む |
+| REQ-F-002      | R-014                                    | pnpm install --frozen-lockfile                     |
+| REQ-F-003      | R-015, R-016, R-017, R-018               | post-install 3項目検証                             |
+| REQ-F-004      | R-019, R-020                             | bin/ を GITHUB_PATH に追記、.repo ファイル作成     |
+| REQ-F-005      | R-005, R-006, R-007, R-008               | Node.js / pnpm セットアップ                        |
+| REQ-NF-001     | R-014（--frozen-lockfile）               | 再現性のあるインストール                           |
+| REQ-NF-002     | —                                        | action.yml の permissions 定義で対応               |
+| REQ-NF-003     | 全 E 系ルール                            | 各ユニット失敗時の即時終了                         |
+| REQ-NF-004     | —                                        | 実装フェーズで既存ライブラリ規約に準拠             |
+
+<!-- impl-note: validate-inputs の repo フォーマット検証は .github/actions/_libs/validation.lib.sh の validate_repo() を再利用できる。path の .. チェックは validate_symbol() では困難なため、個別のパターンマッチで実装すること。 -->
+
+| REQ-C-001 | R-010 | validate-env でランナー OS を確認 |
+| REQ-C-002 | — | token 入力パラメータを持たない |
+| REQ-C-003 | R-012 | validate-env で bin/ 存在を確認 |
+| REQ-C-004 | R-011 | validate-env で pnpm-lock.yaml 存在を確認 |
+| REQ-C-005 | R-001 | repo の owner/repo 形式検証 |
+| REQ-C-006 | R-002 | path の ./ 始まり・.. セグメント禁止 |
+
+---
+
+## 7. Open Questions
+
+> **Status**: INCOMPLETE
+
+| # | Question                                                                  | Source     | Impact                                                  |
+| - | ------------------------------------------------------------------------- | ---------- | ------------------------------------------------------- |
+| 1 | OQ-004: インストールキャッシュ（actions/cache）をアクション内で提供するか | REQ OQ-004 | 提供する場合は setup-environment ユニットに step を追加 |
+
+---
+
+## 8. Change History
+
+| Date       | Version | Description                                                                                |
+| ---------- | ------- | ------------------------------------------------------------------------------------------ |
+| 2026-06-18 | 1.0.0   | Initial specification                                                                      |
+| 2026-06-18 | 1.0.1   | Codex review 反映: validate-env ユニット追加、path を相対パス限定、.. セグメント判定明確化 |
+| 2026-06-18 | 1.0.2   | check-existing-repo ユニット追加、.repo ファイル作成を add-path の最終ステップに追加       |

--- a/docs/.deckrd/composite-action/setup-tool-repo/tasks/tasks.md
+++ b/docs/.deckrd/composite-action/setup-tool-repo/tasks/tasks.md
@@ -1,0 +1,274 @@
+---
+title: "Implementation Tasks: setup-tool-repo Composite Action"
+module: composite-action/setup-tool-repo
+status: Active
+created: "2026-06-18"
+source: specifications.md v1.0.2 / implementation.md v1.0.5
+---
+
+## Task Summary
+
+| Test Target                   | Scenarios | Cases | Status |
+| ----------------------------- | --------- | ----- | ------ |
+| T-01: validate-inputs         | 5         | 10    | done   |
+| T-02: check-existing          | 6         | 6     | done   |
+| T-03: validate-repo-structure | 2         | 3     | done   |
+| T-04: verify-and-add-path     | 6         | 9     | done   |
+| T-05: action.yml integration  | 2         | 4     | done   |
+
+---
+
+## T-01: validate-inputs
+
+> Target: `scripts/_libs/validate-inputs.lib.sh`
+> Spec: R-001, R-002, R-003
+
+### [正常] Normal Cases
+
+#### T-01-01: 有効な入力パラメータ
+
+- [x] **T-01-01-01**: 有効な repo/path/ref を渡すと exit 0 で終了する
+  - Target: `validate-inputs.lib.sh`
+  - Scenario: Given 有効な `owner/repo`・`./tools/agla`・`v1.0.0`, When 検証を実行する
+  - Expected: Then exit 0 で終了する
+
+### [異常] Error Cases
+
+#### T-01-02: repo パラメータ検証（R-001）
+
+- [x] **T-01-02-01**: repo にスラッシュがない場合 exit 1 になる
+  - Target: `validate-inputs.lib.sh`
+  - Scenario: Given `repo="agla-doc-tools"`, When 検証を実行する
+  - Expected: Then `::error::` を stderr に出力し exit 1 で終了する
+
+- [x] **T-01-02-02**: repo に複数スラッシュがある場合 exit 1 になる
+  - Target: `validate-inputs.lib.sh`
+  - Scenario: Given `repo="owner/repo/extra"`, When 検証を実行する
+  - Expected: Then `::error::` を stderr に出力し exit 1 で終了する
+
+#### T-01-03: path パラメータ検証（R-002）
+
+- [x] **T-01-03-01**: path が `./` 始まりでない場合 exit 1 になる
+  - Target: `validate-inputs.lib.sh`
+  - Scenario: Given `path="tools/agla"`（`./` なし）, When 検証を実行する
+  - Expected: Then `::error::` を stderr に出力し exit 1 で終了する
+
+- [x] **T-01-03-02**: path に `..` セグメントが含まれる場合 exit 1 になる
+  - Target: `validate-inputs.lib.sh`
+  - Scenario: Given `path="./foo/../bar"`, When 検証を実行する
+  - Expected: Then `::error::` を stderr に出力し exit 1 で終了する
+
+- [x] **T-01-03-03**: path が絶対パスの場合 exit 1 になる
+  - Target: `validate-inputs.lib.sh`
+  - Scenario: Given `path="/tmp/tools"`, When 検証を実行する
+  - Expected: Then `::error::` を stderr に出力し exit 1 で終了する
+
+#### T-01-04: ref パラメータ検証（R-003）
+
+- [x] **T-01-04-01**: ref が空文字列の場合 exit 1 になる
+  - Target: `validate-inputs.lib.sh`
+  - Scenario: Given `ref=""`, When 検証を実行する
+  - Expected: Then `::error::` を stderr に出力し exit 1 で終了する
+
+- [x] **T-01-04-02**: ref が空白のみの文字列の場合 exit 1 になる（バグ修正）
+  - Target: `validate-inputs.lib.sh`
+  - Scenario: Given `ref="  "`（空白 2 文字）, When 検証を実行する
+  - Expected: Then `::error::` を stderr に出力し exit 1 で終了する（R-003）
+
+### [エッジケース] Edge Cases
+
+#### T-01-05: path の `..` セグメント判定境界（R-002）
+
+- [x] **T-01-05-01**: `./foo..bar` はセグメント内部の `..` なので pass する
+  - Target: `validate-inputs.lib.sh`
+  - Scenario: Given `path="./foo..bar"`（`..` はセグメント全体ではない）, When 検証を実行する
+  - Expected: Then exit 0 で終了する（不正とみなさない）
+
+- [x] **T-01-05-02**: `../outside` は `./` で始まらないため exit 1 になる
+  - Target: `validate-inputs.lib.sh`
+  - Scenario: Given `path="../outside"`（`..` 始まりで `./` 始まりでない）, When 検証を実行する
+  - Expected: Then `::error::` を stderr に出力し exit 1 で終了する（R-002）
+
+---
+
+## T-02: check-existing
+
+> Target: `scripts/_libs/check-existing.lib.sh`
+> Spec: R-005, R-006, R-007, R-008
+> 前提: 全テストケースで `BeforeEach` により `GITHUB_OUTPUT`・`GITHUB_ENV` を `mktemp` で生成した一時ファイルに設定し、`AfterEach` で削除する
+
+### [正常] Normal Cases
+
+#### T-02-01: path が存在しない場合（新規チェックアウト）
+
+- [x] **T-02-01-01**: path が存在しない場合 skip=false を GITHUB_OUTPUT に書き込む
+  - Target: `check-existing.lib.sh`
+  - Scenario: Given `GITHUB_OUTPUT`・`GITHUB_ENV` が `mktemp` ファイルに設定された状態で `path` ディレクトリが存在しない, When check-existing を実行する
+  - Expected: Then ロックを取得し `skip=false` を `GITHUB_OUTPUT` に書き込み、`REPO_LOCK_DIR` を `GITHUB_ENV` に書き込む（R-005）
+
+#### T-02-02: .repo が一致する場合（スキップ）
+
+- [x] **T-02-02-01**: .repo の repo 部分が入力 repo と一致する場合 skip=true を書き込む
+  - Target: `check-existing.lib.sh`
+  - Scenario: Given `GITHUB_OUTPUT`・`GITHUB_ENV` が `mktemp` ファイルに設定された状態で `<path>/.repo` に `owner/repo@abc123` が存在し入力 `repo="owner/repo"`, When check-existing を実行する
+  - Expected: Then `skip=true` を `GITHUB_OUTPUT` に書き込む（R-007）
+
+### [異常] Error Cases
+
+#### T-02-03: .repo が存在しない場合（R-006）
+
+- [x] **T-02-03-01**: path は存在するが .repo がない場合 exit 1 になる
+  - Target: `check-existing.lib.sh`
+  - Scenario: Given `GITHUB_OUTPUT`・`GITHUB_ENV` が `mktemp` ファイルに設定された状態で `path` ディレクトリが存在するが `.repo` が存在しない, When check-existing を実行する
+  - Expected: Then `::error::` を stderr に出力し exit 1 で終了する（R-006）
+
+#### T-02-04: .repo の repo 部分が不一致の場合（R-008）
+
+- [x] **T-02-04-01**: .repo に別 repo が記録されている場合 exit 1 になる
+  - Target: `check-existing.lib.sh`
+  - Scenario: Given `GITHUB_OUTPUT`・`GITHUB_ENV` が `mktemp` ファイルに設定された状態で `<path>/.repo` に `other/repo@abc123` があり入力 `repo="owner/repo"`, When check-existing を実行する
+  - Expected: Then `::error::` を stderr に出力し exit 1 で終了する（R-008）
+
+#### T-02-05: ロック競合
+
+- [x] **T-02-05-01**: .repo.lock が既に存在する場合 exit 1 になる
+  - Target: `check-existing.lib.sh`
+  - Scenario: Given `GITHUB_OUTPUT`・`GITHUB_ENV` が `mktemp` ファイルに設定された状態で `<path>/.repo.lock` ディレクトリが既に存在する, When check-existing を実行する
+  - Expected: Then `::error::` を stderr に出力し exit 1 で終了する（ロック競合）
+
+#### T-02-06: skip=true 時に REPO_LOCK_DIR が GITHUB_ENV に設定される
+
+- [x] **T-02-06-01**: .repo が同一 repo の場合 skip=true とともに REPO_LOCK_DIR が GITHUB_ENV に書き込まれる
+  - Target: `check-existing.lib.sh`
+  - Scenario: Given `GITHUB_OUTPUT`・`GITHUB_ENV` が `mktemp` ファイルに設定された状態で `<path>/.repo` に `owner/repo@abc123` が存在し入力 `repo="owner/repo"`, When check-existing を実行する
+  - Expected: Then `skip=true` を `GITHUB_OUTPUT` に書き込み、かつ `REPO_LOCK_DIR` を `GITHUB_ENV` に書き込む（R-007・ロック取得はスキップを問わず必須）
+
+---
+
+## T-03: validate-repo-structure
+
+> Target: `scripts/_libs/validate-repo-structure.lib.sh`
+> Spec: R-011, R-012
+
+### [正常] Normal Cases
+
+#### T-03-01: pnpm-lock.yaml と bin/ が両方存在する
+
+- [x] **T-03-01-01**: pnpm-lock.yaml と bin/ が存在する場合 exit 0 で終了する
+  - Target: `validate-repo-structure.lib.sh`
+  - Scenario: Given `<path>/pnpm-lock.yaml` と `<path>/bin/` が両方存在する, When 検証を実行する
+  - Expected: Then exit 0 で終了する
+
+### [異常] Error Cases
+
+#### T-03-02: pnpm-lock.yaml が存在しない（R-011）
+
+- [x] **T-03-02-01**: pnpm-lock.yaml が存在しない場合 exit 1 になる
+  - Target: `validate-repo-structure.lib.sh`
+  - Scenario: Given `<path>/pnpm-lock.yaml` が存在しない, When 検証を実行する
+  - Expected: Then `::error::` を stderr に出力し exit 1 で終了する（R-011）
+
+#### T-03-03: bin/ ディレクトリが存在しない（R-012）
+
+- [x] **T-03-03-01**: bin/ が存在しない場合 exit 1 になる
+  - Target: `validate-repo-structure.lib.sh`
+  - Scenario: Given `<path>/bin/` ディレクトリが存在しない, When 検証を実行する
+  - Expected: Then `::error::` を stderr に出力し exit 1 で終了する（R-012）
+
+---
+
+## T-04: verify-and-add-path
+
+> Target: `scripts/_libs/verify-and-add-path.lib.sh`
+> Spec: R-015, R-016, R-017, R-019, R-020, R-020S
+
+### [正常] Normal Cases
+
+#### T-04-01: skip=false（新規チェックアウト）
+
+- [x] **T-04-01-01**: 全検証通過・skip=false の場合 GITHUB_PATH 追記・.repo 書き込み・ロック解放を行う
+  - Target: `verify-and-add-path.lib.sh`
+  - Scenario: Given `node_modules/.bin/`・`bin/` が存在し実行権限あり・`SKIP_REPO=false`・`REPO_LOCK_DIR` に `.repo.lock` パスが設定済み, When verify-and-add-path を実行する
+  - Expected: Then `<path>/bin/` を `GITHUB_PATH` に追記し、`<path>/.repo` に `owner/repo@<sha>` を書き込み、**`<path>/.repo.lock` ディレクトリが存在しない**ことを確認する（R-019, R-020）
+
+#### T-04-02: skip=true（既存チェックアウト再利用）
+
+- [x] **T-04-02-01**: skip=true の場合 .repo 書き込みをスキップしてロックを解放する
+  - Target: `verify-and-add-path.lib.sh`
+  - Scenario: Given 全検証通過・`SKIP_REPO=true`, When verify-and-add-path を実行する
+  - Expected: Then `GITHUB_PATH` 追記を行い、`.repo` 書き込みはスキップし、**`<path>/.repo.lock` ディレクトリが存在しない**ことを確認する（R-020S）
+
+### [異常] Error Cases
+
+#### T-04-03: post-install 検証の失敗ケース（R-015, R-016, R-017）
+
+- [x] **T-04-03-01**: node_modules/.bin/ が存在しない場合 exit 1 になりロックが残存する
+  - Target: `verify-and-add-path.lib.sh`
+  - Scenario: Given `<path>/node_modules/.bin/` が存在しない・`REPO_LOCK_DIR` に `.repo.lock` パスが設定済み, When verify-and-add-path を実行する
+  - Expected: Then `::error::` を stderr に出力し exit 1 で終了し、**`<path>/.repo.lock` ディレクトリが残存している**ことを確認する（R-015、ロック意図的残存）
+
+- [x] **T-04-03-02**: bin/ が空ディレクトリの場合 exit 1 になりロックが残存する
+  - Target: `verify-and-add-path.lib.sh`
+  - Scenario: Given `<path>/bin/` が空ディレクトリ・`REPO_LOCK_DIR` に `.repo.lock` パスが設定済み, When verify-and-add-path を実行する
+  - Expected: Then `::error::` を stderr に出力し exit 1 で終了し、**`<path>/.repo.lock` ディレクトリが残存している**ことを確認する（R-016、ロック意図的残存）
+
+- [x] **T-04-03-03**: bin/ 配下ファイルに実行権限がない場合 exit 1 になりロックが残存する
+  - Target: `verify-and-add-path.lib.sh`
+  - Scenario: Given `<path>/bin/` に実行権限なしのファイルが存在する・`REPO_LOCK_DIR` に `.repo.lock` パスが設定済み, When verify-and-add-path を実行する
+  - Expected: Then `::error::` を stderr に出力し exit 1 で終了し、**`<path>/.repo.lock` ディレクトリが残存している**ことを確認する（R-017、ロック意図的残存）
+
+### [エッジケース] Edge Cases
+
+#### T-04-05: node_modules/.bin/ が空ディレクトリでも pass する（R-015）
+
+- [x] **T-04-05-01**: node_modules/.bin/ が空ディレクトリの場合 exit 0 で終了する
+  - Target: `verify-and-add-path.lib.sh`
+  - Scenario: Given `<path>/node_modules/.bin/` が空ディレクトリ（ファイルなし）・`<path>/bin/` に実行権限ありファイルが存在する, When verify-and-add-path を実行する
+  - Expected: Then exit 0 で終了する（R-015 はディレクトリ存在のみ確認し、内容は問わない）
+
+#### T-04-06: bin/ 配下にシンボリックリンクのみ存在する場合（R-017）
+
+- [x] **T-04-06-01**: bin/ 配下に実行権限を持つシンボリックリンクのみの場合 exit 0 で終了する
+  - Target: `verify-and-add-path.lib.sh`
+  - Scenario: Given `<path>/bin/` に実行権限を持つシンボリックリンクのみが存在する（実体も実行権限あり）, When verify-and-add-path を実行する
+  - Expected: Then exit 0 で終了する（R-017 はシンボリックリンクの実体の権限を確認）
+
+- [x] **T-04-06-02**: bin/ 配下のシンボリックリンクの実体に実行権限がない場合 exit 1 になる
+  - Target: `verify-and-add-path.lib.sh`
+  - Scenario: Given `<path>/bin/` に実行権限のないシンボリックリンクのみが存在する（実体の実行権限なし）, When verify-and-add-path を実行する
+  - Expected: Then `::error::` を stderr に出力し exit 1 で終了する（R-017）
+
+---
+
+## T-05: action.yml integration
+
+> Target: `.github/actions/setup-tool-repo/action.yml`
+> Spec: R-001〜R-020（全ユニット統合）
+
+### [正常] Normal Cases
+
+#### T-05-01: 正常系統合フロー
+
+- [x] **T-05-01-01**: 全スクリプトが連続して pass する（モック環境）
+  - Target: `setup-tool-repo.integration.spec.sh`
+  - Scenario: Given 有効な入力・pnpm-lock.yaml と bin/ が存在・node_modules/.bin/ が存在, When 全スクリプトを順に実行する
+  - Expected: Then 各スクリプトが exit 0 で終了し GITHUB_PATH に bin/ が追記される
+
+- [x] **T-05-01-02**: actionlint と ghalint による action.yml 検証が pass する
+  - Target: `.github/actions/setup-tool-repo/action.yml`
+  - Scenario: Given action.yml が完成した状態, When `actionlint -config-file ./configs/actionlint.yaml` および `ghalint run --config ./configs/ghalint.yaml` をコマンドラインで実行する
+  - Expected: Then 検証エラーなしで exit 0 で終了する（ShellSpec 外のコマンド検証 — Commit 12 で手動確認）
+
+### [異常] Error Cases
+
+#### T-05-02: 異常系統合フロー
+
+- [x] **T-05-02-01**: validate-inputs 失敗時に後続スクリプトが呼ばれない
+  - Target: `setup-tool-repo.integration.spec.sh`
+  - Scenario: Given 不正な `repo` 形式, When validate-inputs スクリプトを実行する
+  - Expected: Then exit 1 で終了し check-existing 以降のスクリプトが実行されない
+
+- [x] **T-05-02-02**: check-existing で repo コンフリクト時に exit 1 になる
+  - Target: `setup-tool-repo.integration.spec.sh`
+  - Scenario: Given `<path>/.repo` に別 repo が記録されている, When check-existing スクリプトを実行する
+  - Expected: Then `::error::` を stderr に出力し exit 1 で終了する

--- a/docs/.deckrd/reusable-workflows/ghalint/specifications/specifications.md
+++ b/docs/.deckrd/reusable-workflows/ghalint/specifications/specifications.md
@@ -44,17 +44,17 @@ ghalint によるワークフローポリシー検証を 7 ステップのシー
 
 #### Feature Decomposition
 
-| Unit            | Responsibility                                              | REQ Coverage               |
-| --------------- | ----------------------------------------------------------- | -------------------------- |
-| trigger-inputs  | 呼び出し側入力とデフォルト値を解決する                      | REQ-F-001, REQ-F-002       |
-| target-checkout | ターゲットリポジトリをワークスペースに配置する              | REQ-F-003                  |
-| env-validation  | ランナー環境と権限を検証する                                | REQ-F-004                  |
-| tool-install    | ghalint バイナリを実行パスにインストールする                | REQ-F-005                  |
-| config-checkout | 共有設定リポジトリを取得してワークスペースに配置する        | REQ-F-006                  |
-| prepare-report  | レポート出力先ディレクトリを準備する                        | REQ-F-007                  |
-| lint-execute    | ghalint を実行しポリシー違反を検出する                      | REQ-F-007                  |
-| report-upload   | 失敗時のみレポートをアーティファクトとして保存する          | REQ-F-008                  |
-| caller-update   | 外部依存をローカル呼び出しに置き換える                      | REQ-F-009                  |
+| Unit            | Responsibility                                       | REQ Coverage         |
+| --------------- | ---------------------------------------------------- | -------------------- |
+| trigger-inputs  | 呼び出し側入力とデフォルト値を解決する               | REQ-F-001, REQ-F-002 |
+| target-checkout | ターゲットリポジトリをワークスペースに配置する       | REQ-F-003            |
+| env-validation  | ランナー環境と権限を検証する                         | REQ-F-004            |
+| tool-install    | ghalint バイナリを実行パスにインストールする         | REQ-F-005            |
+| config-checkout | 共有設定リポジトリを取得してワークスペースに配置する | REQ-F-006            |
+| prepare-report  | レポート出力先ディレクトリを準備する                 | REQ-F-007            |
+| lint-execute    | ghalint を実行しポリシー違反を検出する               | REQ-F-007            |
+| report-upload   | 失敗時のみレポートをアーティファクトとして保存する   | REQ-F-008            |
+| caller-update   | 外部依存をローカル呼び出しに置き換える               | REQ-F-009            |
 
 #### Unit Interaction Map
 
@@ -122,13 +122,13 @@ ghalint によるワークフローポリシー検証を 7 ステップのシー
 
 ### 2.5 Behavioral Design Decisions
 
-| ID    | Decision                                                             | Rationale                                                              | Affected Rules          | Status |
-| ----- | -------------------------------------------------------------------- | ---------------------------------------------------------------------- | ----------------------- | ------ |
-| DD-01 | 外部依存を排除しローカル reusable workflow として実装               | 外部リポジトリの可用性リスクを排除し、バージョン管理を一元化する       | R-001〜R-009            | Active |
-| DD-02 | 設定は `aglabo/.github` からチェックアウト（actionlint パターン踏襲） | 設定の一元管理と `config-file` 入力による上書き可能性を両立する        | R-006, R-007            | Active |
-| DD-03 | 入力パラメータは `ghalint-version` と `config-file` の 2 つ         | 呼び出し側がバージョンと設定パスを制御できる最小限のインターフェース   | R-002                   | Active |
-| DD-04 | ステップ間条件は `steps.<id>.outcome == 'success'` パターン         | プロジェクト既存ワークフロー（actionlint）との一貫性を維持する         | R-001〜R-008            | Active |
-| DD-05 | 失敗時のみレポートをアーティファクトアップロード                    | 成功時のストレージ消費を抑制し、エラー確認の利便性を確保する           | R-009                   | Active |
+| ID    | Decision                                                              | Rationale                                                            | Affected Rules | Status |
+| ----- | --------------------------------------------------------------------- | -------------------------------------------------------------------- | -------------- | ------ |
+| DD-01 | 外部依存を排除しローカル reusable workflow として実装                 | 外部リポジトリの可用性リスクを排除し、バージョン管理を一元化する     | R-001〜R-009   | Active |
+| DD-02 | 設定は `aglabo/.github` からチェックアウト（actionlint パターン踏襲） | 設定の一元管理と `config-file` 入力による上書き可能性を両立する      | R-006, R-007   | Active |
+| DD-03 | 入力パラメータは `ghalint-version` と `config-file` の 2 つ           | 呼び出し側がバージョンと設定パスを制御できる最小限のインターフェース | R-002          | Active |
+| DD-04 | ステップ間条件は `steps.<id>.outcome == 'success'` パターン           | プロジェクト既存ワークフロー（actionlint）との一貫性を維持する       | R-001〜R-008   | Active |
+| DD-05 | 失敗時のみレポートをアーティファクトアップロード                      | 成功時のストレージ消費を抑制し、エラー確認の利便性を確保する         | R-009          | Active |
 
 ### 2.6 Related Decision Records
 
@@ -222,25 +222,25 @@ DD-01（外部依存排除）と DD-02（設定リポジトリ固定）は、他
 
 Evaluation MUST follow this order:
 
-| Rule ID | Step | Condition                                              | Outcome                                          |
-| ------- | ---: | ------------------------------------------------------ | ------------------------------------------------ |
-| R-001   |    1 | workflow_call で呼び出された                           | trigger-inputs を実行し入力値を解決する          |
-| R-002   |    2 | ghalint-version が指定された                           | 指定バージョンを使用する                         |
-| R-002a  |    2 | ghalint-version が省略された                           | デフォルトバージョンを使用する                   |
-| R-003   |    3 | config-file が指定された                               | 指定パスを使用する                               |
-| R-003a  |    3 | config-file が省略された                               | `./shared/configs/ghalint.yaml` を使用する       |
-| R-004   |    4 | target-checkout が成功した                             | env-validation を実行する                        |
-| R-004a  |    4 | target-checkout が失敗した                             | 後続全ステップをブロックしジョブを失敗させる     |
-| R-005   |    5 | env-validation が成功した                              | tool-install を実行する                          |
-| R-005a  |    5 | env-validation が失敗した                              | tool-install 以降をブロックしジョブを失敗させる  |
-| R-006   |    6 | tool-install が成功した                                | config-checkout を実行する                       |
-| R-006a  |    6 | tool-install が失敗した                                | config-checkout 以降をブロックしジョブを失敗させる |
-| R-007   |    7 | config-checkout が成功した                             | prepare-report を実行する                        |
-| R-007a  |    7 | config-checkout が失敗した                             | prepare-report 以降をブロックしジョブを失敗させる |
-| R-008   |    8 | prepare-report が成功した                              | lint-execute を実行する                          |
-| R-008a  |    8 | prepare-report が失敗した                              | lint-execute をブロックしジョブを失敗させる      |
-| R-009   |    9 | lint-execute が成功した（exit code 0）                 | ジョブを成功させる。アーティファクトを保存しない |
-| R-009a  |    9 | lint-execute が失敗した（exit code 非ゼロ）            | report-upload を実行してアーティファクトを保存する |
+| Rule ID | Step | Condition                                   | Outcome                                            |
+| ------- | ---: | ------------------------------------------- | -------------------------------------------------- |
+| R-001   |    1 | workflow_call で呼び出された                | trigger-inputs を実行し入力値を解決する            |
+| R-002   |    2 | ghalint-version が指定された                | 指定バージョンを使用する                           |
+| R-002a  |    2 | ghalint-version が省略された                | デフォルトバージョンを使用する                     |
+| R-003   |    3 | config-file が指定された                    | 指定パスを使用する                                 |
+| R-003a  |    3 | config-file が省略された                    | `./shared/configs/ghalint.yaml` を使用する         |
+| R-004   |    4 | target-checkout が成功した                  | env-validation を実行する                          |
+| R-004a  |    4 | target-checkout が失敗した                  | 後続全ステップをブロックしジョブを失敗させる       |
+| R-005   |    5 | env-validation が成功した                   | tool-install を実行する                            |
+| R-005a  |    5 | env-validation が失敗した                   | tool-install 以降をブロックしジョブを失敗させる    |
+| R-006   |    6 | tool-install が成功した                     | config-checkout を実行する                         |
+| R-006a  |    6 | tool-install が失敗した                     | config-checkout 以降をブロックしジョブを失敗させる |
+| R-007   |    7 | config-checkout が成功した                  | prepare-report を実行する                          |
+| R-007a  |    7 | config-checkout が失敗した                  | prepare-report 以降をブロックしジョブを失敗させる  |
+| R-008   |    8 | prepare-report が成功した                   | lint-execute を実行する                            |
+| R-008a  |    8 | prepare-report が失敗した                   | lint-execute をブロックしジョブを失敗させる        |
+| R-009   |    9 | lint-execute が成功した（exit code 0）      | ジョブを成功させる。アーティファクトを保存しない   |
+| R-009a  |    9 | lint-execute が失敗した（exit code 非ゼロ） | report-upload を実行してアーティファクトを保存する |
 
 No reordering is permitted.
 
@@ -248,39 +248,39 @@ No reordering is permitted.
 
 ## 5. Edge Cases
 
-| Scenario                                               | 振る舞い                                        | REQ           | Rationale                                      |
-| ------------------------------------------------------ | ----------------------------------------------- | ------------- | ---------------------------------------------- |
-| `config-file` に存在しないパスを指定                   | lint-execute が失敗し report-upload が実行される | REQ-F-007     | ghalint は設定ファイル不在時に非ゼロ終了する   |
-| `ghalint-version` に存在しないバージョンを指定         | tool-install が失敗し後続がブロックされる        | REQ-F-005     | setup-tool は Releases に存在しない版を取得できない |
-| `aglabo/.github` に `shared/configs/ghalint.yaml` が不在 | lint-execute が失敗し report-upload が実行される | REQ-F-006     | Open Question — 存在確認が必要                 |
-| `.github/report/` が既に存在する状態で再実行           | prepare-report が正常終了し lint-execute へ進む  | REQ-F-007     | ディレクトリ作成は冪等                         |
-| ポリシー違反がゼロ件                                   | lint-execute が exit code 0 で終了しジョブ成功   | REQ-F-007     | 正常系                                         |
-| ポリシー違反が 1 件以上                                | lint-execute が非ゼロで終了しジョブ失敗          | REQ-F-007     | 違反を CI 失敗として確実に伝播させる           |
-| report-upload 自体が失敗                               | ジョブはすでに失敗状態であり追加エラーは記録される | REQ-F-008   | 非致命的な後処理                               |
+| Scenario                                                 | 振る舞い                                           | REQ       | Rationale                                           |
+| -------------------------------------------------------- | -------------------------------------------------- | --------- | --------------------------------------------------- |
+| `config-file` に存在しないパスを指定                     | lint-execute が失敗し report-upload が実行される   | REQ-F-007 | ghalint は設定ファイル不在時に非ゼロ終了する        |
+| `ghalint-version` に存在しないバージョンを指定           | tool-install が失敗し後続がブロックされる          | REQ-F-005 | setup-tool は Releases に存在しない版を取得できない |
+| `aglabo/.github` に `shared/configs/ghalint.yaml` が不在 | lint-execute が失敗し report-upload が実行される   | REQ-F-006 | Open Question — 存在確認が必要                      |
+| `.github/report/` が既に存在する状態で再実行             | prepare-report が正常終了し lint-execute へ進む    | REQ-F-007 | ディレクトリ作成は冪等                              |
+| ポリシー違反がゼロ件                                     | lint-execute が exit code 0 で終了しジョブ成功     | REQ-F-007 | 正常系                                              |
+| ポリシー違反が 1 件以上                                  | lint-execute が非ゼロで終了しジョブ失敗            | REQ-F-007 | 違反を CI 失敗として確実に伝播させる                |
+| report-upload 自体が失敗                                 | ジョブはすでに失敗状態であり追加エラーは記録される | REQ-F-008 | 非致命的な後処理                                    |
 
 ---
 
 ## 6. Requirements Traceability
 
-| Requirement ID | Spec Rule            | Notes                                             |
-| -------------- | -------------------- | ------------------------------------------------- |
-| REQ-F-001      | R-001                | workflow_call トリガーのみ受け付ける              |
-| REQ-F-002      | R-002, R-002a, R-003, R-003a | 入力パラメータのデフォルト解決                  |
-| REQ-F-003      | R-004, R-004a        | target-checkout の成功/失敗分岐                  |
-| REQ-F-004      | R-005, R-005a        | env-validation の成功/失敗分岐                   |
-| REQ-F-005      | R-006, R-006a        | tool-install の成功/失敗分岐                     |
-| REQ-F-006      | R-007, R-007a        | config-checkout の成功/失敗分岐                  |
-| REQ-F-007      | R-008, R-008a, R-009 | prepare-report + lint-execute の実行と結果伝播   |
-| REQ-F-008      | R-009a               | 失敗時のみ report-upload を実行                  |
-| REQ-F-009      | DD-01                | ci-workflows-qa.yml の外部依存をローカルに置き換える（実装フェーズで扱う） |
-| REQ-NF-001     | Section 3.3 全 Unit  | 全チェックアウトで認証情報保護、最小権限を適用   |
-| REQ-NF-002     | Section 2.3          | actionlint 7 ステップパターンに準拠              |
-| REQ-NF-003     | Section 2.5 DD-04    | SHA ピン・タイムアウト設定は実装フェーズで扱う   |
-| REQ-NF-004     | Section 2.3 Unit 名  | ステップ ID 命名規則は actionlint と統一          |
-| REQ-C-001      | Section 2.2          | ubuntu-slim ランナーを前提とする                 |
-| REQ-C-002      | Section 2.5 DD-04    | `steps.<id>.outcome == 'success'` パターンのみ   |
-| REQ-C-003      | R-001                | workflow_call トリガーのみ                       |
-| REQ-C-004      | Section 3.3 config-checkout | aglabo/.github を設定ソースとして使用    |
+| Requirement ID | Spec Rule                    | Notes                                                                      |
+| -------------- | ---------------------------- | -------------------------------------------------------------------------- |
+| REQ-F-001      | R-001                        | workflow_call トリガーのみ受け付ける                                       |
+| REQ-F-002      | R-002, R-002a, R-003, R-003a | 入力パラメータのデフォルト解決                                             |
+| REQ-F-003      | R-004, R-004a                | target-checkout の成功/失敗分岐                                            |
+| REQ-F-004      | R-005, R-005a                | env-validation の成功/失敗分岐                                             |
+| REQ-F-005      | R-006, R-006a                | tool-install の成功/失敗分岐                                               |
+| REQ-F-006      | R-007, R-007a                | config-checkout の成功/失敗分岐                                            |
+| REQ-F-007      | R-008, R-008a, R-009         | prepare-report + lint-execute の実行と結果伝播                             |
+| REQ-F-008      | R-009a                       | 失敗時のみ report-upload を実行                                            |
+| REQ-F-009      | DD-01                        | ci-workflows-qa.yml の外部依存をローカルに置き換える（実装フェーズで扱う） |
+| REQ-NF-001     | Section 3.3 全 Unit          | 全チェックアウトで認証情報保護、最小権限を適用                             |
+| REQ-NF-002     | Section 2.3                  | actionlint 7 ステップパターンに準拠                                        |
+| REQ-NF-003     | Section 2.5 DD-04            | SHA ピン・タイムアウト設定は実装フェーズで扱う                             |
+| REQ-NF-004     | Section 2.3 Unit 名          | ステップ ID 命名規則は actionlint と統一                                   |
+| REQ-C-001      | Section 2.2                  | ubuntu-slim ランナーを前提とする                                           |
+| REQ-C-002      | Section 2.5 DD-04            | `steps.<id>.outcome == 'success'` パターンのみ                             |
+| REQ-C-003      | R-001                        | workflow_call トリガーのみ                                                 |
+| REQ-C-004      | Section 3.3 config-checkout  | aglabo/.github を設定ソースとして使用                                      |
 
 ---
 
@@ -288,10 +288,10 @@ No reordering is permitted.
 
 > **Status**: INCOMPLETE
 
-| # | Question                                                                              | Source        | Impact                                                        |
-| - | ------------------------------------------------------------------------------------- | ------------- | ------------------------------------------------------------- |
-| 1 | ghalint のデフォルトバージョン番号は何か（`suzuki-shunsuke/ghalint` 最新安定版）      | REQ-F-005     | trigger-inputs のデフォルト値が未確定                         |
-| 2 | `aglabo/.github` リポジトリに `shared/configs/ghalint.yaml` が存在するか              | REQ-F-006     | 存在しない場合、config-checkout ステップの設計変更が必要      |
+| # | Question                                                                         | Source    | Impact                                                   |
+| - | -------------------------------------------------------------------------------- | --------- | -------------------------------------------------------- |
+| 1 | ghalint のデフォルトバージョン番号は何か（`suzuki-shunsuke/ghalint` 最新安定版） | REQ-F-005 | trigger-inputs のデフォルト値が未確定                    |
+| 2 | `aglabo/.github` リポジトリに `shared/configs/ghalint.yaml` が存在するか         | REQ-F-006 | 存在しない場合、config-checkout ステップの設計変更が必要 |
 
 ---
 

--- a/docs/.deckrd/reusable-workflows/ghalint/tasks/tasks.md
+++ b/docs/.deckrd/reusable-workflows/ghalint/tasks/tasks.md
@@ -10,13 +10,13 @@ source: specifications.md
 
 ## Task Summary
 
-| Test Target                  | Scenarios | Cases | Status      |
-| ---------------------------- | --------- | ----- | ----------- |
-| T-01: ci-qa-ghalint.yml      | 4         | 12    | completed   |
-| T-02: trigger-inputs         | 2         | 4     | completed   |
-| T-03: step-gating            | 3         | 8     | completed   |
-| T-04: lint-execute           | 2         | 4     | completed   |
-| T-05: ci-workflows-qa update | 2         | 3     | completed   |
+| Test Target                  | Scenarios | Cases | Status    |
+| ---------------------------- | --------- | ----- | --------- |
+| T-01: ci-qa-ghalint.yml      | 4         | 12    | completed |
+| T-02: trigger-inputs         | 2         | 4     | completed |
+| T-03: step-gating            | 3         | 8     | completed |
+| T-04: lint-execute           | 2         | 4     | completed |
+| T-05: ci-workflows-qa update | 2         | 3     | completed |
 
 ---
 


### PR DESCRIPTION
## Overview

**Summary**
Adds `setup-tool-repo` composite action that automates tool repository checkout and setup.

**Background / Motivation**
Workflows need a consistent, reusable way to check out tool repositories and configure the environment. This action centralizes that logic — validating inputs, detecting existing checkouts, installing dependencies, and registering the path — so individual workflows stay simple and DRY.

## Changes

### Core Changes

- `.github/actions/setup-tool-repo/action.yml`: composite action with 8 steps. Accepts `repo`, `path`, `ref`, `node-version`, and `pnpm-version` inputs. Exposes a `skip` output when an existing checkout is detected.

- `scripts/_libs/validate-inputs.lib.sh`: validates `repo` (owner/repo format), `path` (no traversal), and `ref` (non-empty).
- `scripts/_libs/check-existing.lib.sh`: detects an existing checkout, acquires a lock, and verifies identity via `.repo` marker file. Exports `SKIP_REPO`.
- `scripts/_libs/validate-repo-structure.lib.sh`: confirms `pnpm-lock.yaml` and `bin/` exist after checkout.
- `scripts/_libs/verify-and-add-path.lib.sh`: verifies installation, registers `GITHUB_PATH`, writes `.repo` marker, and removes the lock directory.

### Test Updates

- `__tests__/unit/validate-inputs.unit.spec.sh`
- `__tests__/unit/check-existing.unit.spec.sh` (T-02-01 through T-02-06)
- `__tests__/unit/validate-repo-structure.unit.spec.sh`
- `__tests__/unit/verify-and-add-path.unit.spec.sh`
- `__tests__/integration/setup-tool-repo.integration.spec.sh` (T-05-01-01, T-05-02-01, T-05-02-02)

### Removed

N/A

## Change Type (optional)

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Related to #82

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

- Each library uses a load-guard (`*_LIB_LOADED` variable) to prevent double-sourcing.
- `verify-and-add-path` applies `chmod +x` automatically before verifying executability.
- Tests use `BeforeEach`/`AfterEach` with `mktemp` temp dirs and mock `GITHUB_PATH`, `GITHUB_ENV`, `GITHUB_OUTPUT` files.
- When an existing checkout is detected, `validate-repo-structure` and `install-packages` steps are skipped to avoid redundant work.
