### PR TITLE
refactor(ca-setup-repo): replace rg with find+grep for executable discovery

### DIFF
--- a/.github/actions/ca-setup-repo/action.yml
+++ b/.github/actions/ca-setup-repo/action.yml
@@ -48,6 +48,14 @@ runs:
         REPO: ${{ inputs.repo }}
         PATH_DIR: ${{ inputs.path }}
 
+    - name: checkout-repo
+      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      with:
+        repository: ${{ inputs.repo }}
+        path: ${{ inputs.path }}
+        ref: ${{ inputs.ref }}
+        persist-credentials: false
+
     - name: setup-pnpm
       uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
       with:
@@ -59,14 +67,6 @@ runs:
         node-version: ${{ inputs.node-version }}
         cache: "pnpm"
         cache-dependency-path: ${{ inputs.path }}/pnpm-lock.yaml
-
-    - name: checkout-repo
-      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
-      with:
-        repository: ${{ inputs.repo }}
-        path: ${{ inputs.path }}
-        ref: ${{ inputs.ref }}
-        persist-credentials: false
 
     - name: validate-repo-structure
       if: steps.check-existing-repo.outputs.skip != 'true'

--- a/.github/actions/ca-setup-repo/scripts/_libs/__tests__/unit/verify-and-add-path.unit.spec.sh
+++ b/.github/actions/ca-setup-repo/scripts/_libs/__tests__/unit/verify-and-add-path.unit.spec.sh
@@ -60,6 +60,7 @@ Describe 'Given: node_modules/.bin/ exists, bin/ has executable file, SKIP_REPO=
         mkdir -p "${_TEST_DIR}/node_modules/.bin"
         mkdir -p "${_TEST_DIR}/bin"
         printf '#!/bin/bash\necho hello\n' > "${_TEST_DIR}/bin/mytool"
+        #shellcheck disable=SC2034
         SKIP_REPO="true"
         When call verify_and_add_path "${_TEST_DIR}" "owner/repo" "abc123"
         The status should equal 0
@@ -177,6 +178,26 @@ Describe 'Given: bin/ has only a symlink pointing to a non-executable target (to
         When run verify_and_add_path "${_TEST_DIR}" "owner/repo" "abc123"
         The stderr should include "::error::"
         The status should equal 1
+      End
+    End
+  End
+End
+
+# T-04-07: [エッジケース] bin/libs/ 以下の非実行ファイルは候補に含まれない
+
+Describe 'Given: bin/ has executable file, bin/libs/ has non-executable .lib.sh'
+  BeforeEach 'setup_env'
+  AfterEach 'cleanup_env'
+  Describe 'When: verify_and_add_path is called'
+    Describe 'Then: Task T-04-07-01 - libs/*.lib.sh excluded from candidates, exit 0'
+      It "T-04-07-01: exits 0 (bin/libs/ subdirectory is not checked for execute permission)"
+        mkdir -p "${_TEST_DIR}/node_modules/.bin"
+        mkdir -p "${_TEST_DIR}/bin/libs"
+        printf '#!/bin/bash\necho hello\n' > "${_TEST_DIR}/bin/mytool"
+        chmod +x "${_TEST_DIR}/bin/mytool"
+        touch "${_TEST_DIR}/bin/libs/resolve-paths.lib.sh"
+        When call verify_and_add_path "${_TEST_DIR}" "owner/repo" "abc123"
+        The status should equal 0
       End
     End
   End

--- a/.github/actions/ca-setup-repo/scripts/_libs/verify-and-add-path.lib.sh
+++ b/.github/actions/ca-setup-repo/scripts/_libs/verify-and-add-path.lib.sh
@@ -6,6 +6,23 @@
 [ -n "${VERIFY_AND_ADD_PATH_LIB_LOADED:-}" ] && return 0
 VERIFY_AND_ADD_PATH_LIB_LOADED=1
 
+# @description List bin/ candidates: files with no extension or .sh extension
+# @arg $1 _bin_dir — path to bin/ directory
+# @stdout newline-separated file paths
+_list_bin_candidates() {
+  local _bin_dir="$1"
+  find -L "${_bin_dir}" -maxdepth 1 -type f 2>/dev/null | grep -E '/[^./]+$|/[^/]+\.sh$'
+}
+
+# @description Filter to files that have a shebang line
+# @stdin newline-separated file paths
+# @stdout newline-separated file paths with shebang
+_filter_shebang() {
+  while IFS= read -r _f; do
+    head -c 2 "${_f}" 2>/dev/null | grep -q '^#!' && echo "${_f}"
+  done
+}
+
 ##
 # @description Verify post-install structure and add bin/ to GITHUB_PATH.
 # @arg $1 _path    — checked-out repo root
@@ -26,30 +43,31 @@ verify_and_add_path() {
     return 1
   fi
 
-  # R-016: bin/ must contain at least one file
-  local _has_file=false
-  for _f in "${_path}/bin/"*; do
-    [[ -e "${_f}" ]] || continue
-    _has_file=true
-    break
-  done
-  if [[ "${_has_file}" == false ]]; then
-    echo "::error::verify-and-add-path: no files found in ${_path}/bin/" >&2
+  # R-016: bin/ must contain at least one candidate (no extension or .sh)
+  local _candidates
+  _candidates=$(_list_bin_candidates "${_path}/bin")
+  if [[ -z "${_candidates}" ]]; then
+    echo "::error::verify-and-add-path: no executable candidates found in ${_path}/bin/" >&2
     return 1
   fi
 
-  # R-017: all files in bin/ must have execute permission
-  for _f in "${_path}/bin/"*; do
-    [[ -e "${_f}" ]] || continue
-    # shebang があれば実行ビットを付与（Windows では chmod が必要）
-    if head -c 2 "${_f}" 2>/dev/null | grep -q '^#!'; then
+  # R-017: chmod +x all shebang files, then verify execute permission
+  local _shebang_files
+  _shebang_files=$(echo "${_candidates}" | _filter_shebang)
+  if [[ -n "${_shebang_files}" ]]; then
+    while IFS= read -r _f; do
       chmod +x "${_f}"
-    fi
+    done <<< "${_shebang_files}"
+  fi
+
+  local _failed=false
+  while IFS= read -r _f; do
     if [[ ! -x "${_f}" ]]; then
       echo "::error::verify-and-add-path: file not executable: ${_f}" >&2
-      return 1
+      _failed=true
     fi
-  done
+  done <<< "${_candidates}"
+  [[ "${_failed}" == true ]] && return 1
 
   # R-019: append bin/ to GITHUB_PATH
   echo "${_path}/bin" >> "${GITHUB_PATH}"

--- a/.github/workflows/_tests_ca_composite-actions.yml
+++ b/.github/workflows/_tests_ca_composite-actions.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           repo: aglabo/agla-dev-tools
           path: ./tools/agla-dev-tools
-          ref: a88f3bf1ecda478ad8ec2e907139bd058ce5ee56 # main(latest)
+          ref: a88f3bf1ecda478ad8ec2e907139bd058ce5ee56 # v0.1.0
 
       - name: Verify ls-lint
         id: verify-ls-lint

--- a/.github/workflows/_tests_ca_composite-actions.yml
+++ b/.github/workflows/_tests_ca_composite-actions.yml
@@ -6,6 +6,8 @@
 # This software is released under the MIT License.
 # https://opensource.org/licenses/MIT
 
+# cspell:words rhysd
+
 name: "TestRunner for CA Composite Actions"
 
 permissions:
@@ -16,8 +18,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  test-validate-environment:
-    name: Test ca-validate-environment
+  setup-foundation:
+    name: Setup Foundation (ca-validate-environment)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -29,12 +31,75 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Test ca-validate-environment
-        id: test-validate-env
+      - name: Validate environment
+        id: validate-env
         if: steps.checkout.outcome == 'success'
         uses: ./.github/actions/ca-validate-environment
         with:
           actions-type: read
+
+  test-setup-tool:
+    name: Test ca-setup-tool
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs:
+      - setup-foundation
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        id: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Test ca-setup-tool
+        id: test-setup-tool
+        if: steps.checkout.outcome == 'success'
+        uses: ./.github/actions/ca-setup-tool
+        with:
+          repo: rhysd/actionlint
+          tool-version: "1.7.12"
+
+      - name: Verify installed tool
+        id: verify-tool
+        if: steps.test-setup-tool.outcome == 'success'
+        run: |
+          _version=$(actionlint -version 2>&1 | head -n 1)
+          echo "actionlint version: ${_version}"
+          echo "version=${_version}" >> "${GITHUB_OUTPUT}"
+
+  test-setup-repo:
+    name: Test ca-setup-repo
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs:
+      - setup-foundation
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        id: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Test ca-setup-repo
+        id: test-setup-repo
+        if: steps.checkout.outcome == 'success'
+        uses: ./.github/actions/ca-setup-repo
+        with:
+          repo: aglabo/agla-dev-tools
+          path: ./tools/agla-dev-tools
+          ref: a88f3bf1ecda478ad8ec2e907139bd058ce5ee56 # main(latest)
+
+      - name: Verify ls-lint
+        id: verify-ls-lint
+        if: steps.test-setup-repo.outcome == 'success'
+        run: |
+          _version=$(ls-lint --version 2>&1 | head -n 1)
+          echo "ls-lint version: ${_version}"
+          echo "version=${_version}" >> "${GITHUB_OUTPUT}"
 
   summary:
     name: Test Summary
@@ -42,13 +107,17 @@ jobs:
     timeout-minutes: 5
     if: always()
     needs:
-      - test-validate-environment
+      - setup-foundation
+      - test-setup-tool
+      - test-setup-repo
     permissions:
       contents: read
     steps:
       - name: Report results
         env:
-          RESULT_VALIDATE_ENV: ${{ needs.test-validate-environment.result }}
+          RESULT_FOUNDATION: ${{ needs.setup-foundation.result }}
+          RESULT_SETUP_TOOL: ${{ needs.test-setup-tool.result }}
+          RESULT_SETUP_REPO: ${{ needs.test-setup-repo.result }}
         run: |
           _failed=0
 
@@ -61,9 +130,13 @@ jobs:
             echo ""
             echo "| Job | Result |"
             echo "| --- | ------ |"
-            echo "| test-validate-environment | $(_status "${RESULT_VALIDATE_ENV}") |"
+            echo "| setup-foundation | $(_status "${RESULT_FOUNDATION}") |"
+            echo "| test-setup-tool  | $(_status "${RESULT_SETUP_TOOL}") |"
+            echo "| test-setup-repo  | $(_status "${RESULT_SETUP_REPO}") |"
           } >> "${GITHUB_STEP_SUMMARY}"
 
-          [ "${RESULT_VALIDATE_ENV}" = "success" ] || _failed=1
+          [ "${RESULT_FOUNDATION}" = "success" ] || _failed=1
+          [ "${RESULT_SETUP_TOOL}" = "success" ] || _failed=1
+          [ "${RESULT_SETUP_REPO}" = "success" ] || _failed=1
 
           exit "${_failed}"


### PR DESCRIPTION
## Overview

**Summary**
Replace `rg` (ripgrep) with `find`+`grep` in `_list_bin_candidates()` to remove the dependency on a non-standard tool.

**Background / Motivation**
`rg` is not installed in ubuntu-slim environments, causing `ca-setup-repo` to fail with `command not found`.
Switching to standard POSIX tools (`find`/`grep`) ensures the action works across all Ubuntu runner variants.
 A `-maxdepth 1` flag is also added to prevent non-executable library files under `bin/libs/` from being included
  in the candidate list.

## Changes

### Core Changes

- `.github/actions/ca-setup-repo/scripts/_libs/verify-and-add-path.lib.sh`
  - Replace `rg --files --follow` with `find -L` in `_list_bin_candidates()`
  - Add `-maxdepth 1` to exclude files under `bin/libs/` subdirectories

### Test Updates

- `.github/actions/ca-setup-repo/scripts/_libs/__tests__/unit/verify-and-add-path.unit.spec.sh`
  - Add T-04-07-01: verify that non-executable files under `bin/libs/` are excluded from candidates

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Configuration
- [x] CI/CD
- [ ] Other

## Related Issues

> Closes #86

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

- Using `find`/`grep` ensures portability across all runner images.
- The `ref` comment in `_tests_ca_composite-actions.yml` is also updated from `# main(latest)` to `# v0.1.0`.
