### PR TITLE
release(docs): add v0.3.1 changelog and release note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,50 @@
 ---
 title: "ci-platform Change Log"
-version: "0.3.0"
-date: 2026-06-21
+version: "0.3.1"
+date: 2026-06-22
 tags:
   - release
   - composite-actions
-  - reusable-workflows
   - ci-platform
 summary: >
-  v0.3.0 unifies composite action and reusable workflow naming conventions,
-  adds the ca-setup-repo composite action, introduces a Docusaurus documentation
-  publishing pipeline, and pins all caller workflows to external repository references.
+  v0.3.1 adds the ca-get-changed-files composite action for detecting changed files
+  between commits in push events.
+---
+
+<!-- textlint-disable
+  ja-technical-writing/sentence-length,
+  ja-technical-writing/max-comma
+  -->
+
+## [0.3.1] - 2026-06-22
+
+### Overview
+
+This release adds `ca-get-changed-files`, a composite action that detects changed files
+between before/after commits in push events.
+
+It supports glob pattern filtering and outputs the changed file list and count,
+enabling downstream jobs and steps to use them for conditional branching or file processing.
+
+---
+
+### Added
+
+#### Composite Actions
+
+- `ca-get-changed-files`: Detects changed files between commits in push events.
+  Accepts an optional `pattern` input for glob filtering, and exposes `before-sha` / `after-sha`
+  inputs to override the default commit SHAs (`github.event.before` / `github.sha`).
+  Outputs `files` (newline-separated paths) and `count` (number of changed files).
+  Requires `actions/checkout` with `fetch-depth: 0`.
+
+---
+
+### Notes
+
+- `ca-get-changed-files` behavior is verified by integration tests covering
+  no-pattern, pattern-match, and pattern-no-match scenarios.
+
 ---
 
 ## [0.3.0] - 2026-06-21

--- a/Release-Note.md
+++ b/Release-Note.md
@@ -1,0 +1,69 @@
+---
+title: "ci-platform Release Notes v0.3.1"
+version: "0.3.1"
+date: 2026-06-22
+tags:
+  - release
+  - composite-actions
+summary: >
+  v0.3.1 では、push イベントでコミット間の変更ファイルを検出する
+  ca-get-changed-files コンポジットアクションを追加しました。
+---
+
+## [0.3.1] - 2026-06-22
+
+### Overview
+
+このリリースでは、`ca-get-changed-files` コンポジットアクションを新たに追加しました。
+
+push イベントの before/after コミット間で変更されたファイルを取得し、
+glob パターンによるフィルタリングに対応します。
+変更ファイルの一覧と件数を出力として提供するため、
+後続のジョブやステップで条件分岐・ファイル処理に活用できます。
+
+---
+
+### Added
+
+#### Composite Actions
+
+- `ca-get-changed-files`: push イベントで変更されたファイルを検出するコンポジットアクション。
+
+  入力パラメータ:
+
+  | パラメータ   | 必須 | デフォルト            | 説明                                 |
+  | ------------ | ---- | --------------------- | ------------------------------------ |
+  | `pattern`    | 任意 | `""` (全ファイル)     | 変更ファイルを絞り込む glob パターン |
+  | `before-sha` | 任意 | `github.event.before` | 比較元コミット SHA                   |
+  | `after-sha`  | 任意 | `github.sha`          | 比較先コミット SHA                   |
+
+  出力:
+
+  | 出力    | 説明                                 |
+  | ------- | ------------------------------------ |
+  | `files` | 変更ファイルのパス一覧（改行区切り） |
+  | `count` | 変更ファイルの件数                   |
+
+  前提条件: `actions/checkout` で `fetch-depth: 0` の設定が必須です。
+
+  使用例:
+
+  ```yaml
+  - uses: actions/checkout@v4
+    with:
+      fetch-depth: 0
+
+  - uses: aglabo/ci-platform/.github/actions/ca-get-changed-files@v0.3.1
+    id: changed
+    with:
+      pattern: "src/**/*.ts"
+
+  - run: echo "Changed files: ${{ steps.changed.outputs.files }}"
+  ```
+
+---
+
+### Notes
+
+- `ca-get-changed-files` はパターンなし・マッチあり・マッチなしのシナリオを含む
+  インテグレーションテストで動作を検証済みです。


### PR DESCRIPTION
## Overview

**Summary**
Adds CHANGELOG and Release Note for the v0.3.1 release.

**Background / Motivation**
The `ca-get-changed-files` composite action was added in v0.3.1. This PR documents that release with an updated CHANGELOG and a new Release Note covering inputs, outputs, usage examples, and prerequisites.

## Changes

### Core Changes

- `CHANGELOG.md` — Added v0.3.1 section documenting `ca-get-changed-files` (specs and test coverage)
- `Release-Note.md` — New file with the v0.3.1 release note (inputs, outputs, usage example, notes)

### Test Updates

N/A

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [x] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

This is a documentation-only change. No functional code was modified.
