### PR TITLE
release(v0.3.1): add ca-get-changed-files action and update workflow SHAs

### DIFF
--- a/.github/actions/ca-get-changed-files/action.yml
+++ b/.github/actions/ca-get-changed-files/action.yml
@@ -1,0 +1,47 @@
+# src: ./.github/actions/validate-environment/action.yml
+# @(#) : Composite: get changes files on push
+#
+# Copyright (c) 2026- aglabo <https://github.com/aglabo>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+name: "get-changed-files"
+description: |
+  Get changed files between push before/after commits using git diff.
+  IMPORTANT: Requires fetch-depth: 0 in actions/checkout step.
+  Only works with push events (uses github.event.before and github.sha internally).
+
+inputs:
+  before-sha:
+    description: "SHA of the commit before the push. Defaults to github.event.before (push events). Override for testing or non-push events."
+    required: false
+    default: ${{ github.event.before }}
+  after-sha:
+    description: "SHA of the commit after the push. Defaults to github.sha."
+    required: false
+    default: ${{ github.sha }}
+  pattern:
+    description: "Git pathspec glob filter (e.g. '*.ts', 'src/**/*.sh'). Empty = all files."
+    required: false
+    default: ""
+
+outputs:
+  files:
+    description: "Newline-separated list of changed file paths (added/copied/modified/renamed)"
+    value: ${{ steps.get-changed-files.outputs.files }}
+  count:
+    description: "Number of changed files"
+    value: ${{ steps.get-changed-files.outputs.count }}
+
+runs:
+  using: composite
+  steps:
+    - name: Get changed files
+      id: get-changed-files
+      shell: bash
+      run: bash "${{ github.action_path }}/scripts/get-changed-files.sh"
+      env:
+        BEFORE_SHA: ${{ inputs.before-sha }}
+        AFTER_SHA: ${{ inputs.after-sha }}
+        PATTERN: ${{ inputs.pattern }}

--- a/.github/actions/ca-get-changed-files/scripts/__tests__/functional/get-changed-files.functional.spec.sh
+++ b/.github/actions/ca-get-changed-files/scripts/__tests__/functional/get-changed-files.functional.spec.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# src: .github/actions/ca-get-changed-files/scripts/__tests__/functional/get-changed-files.functional.spec.sh
+# @(#) : get-changed-files.sh 機能テスト
+#
+# Copyright (c) 2026- atsushifx <atsushifx@gmail.com>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+# shellcheck shell=bash
+
+# ─── Internal Helpers ───────────────────────────────────────────────────────
+
+_SCRIPT_PATH="${SHELLSPEC_PROJECT_ROOT}/.github/actions/ca-get-changed-files/scripts/get-changed-files.sh"
+_NORMAL_BEFORE="abc1234567890abcdef1234567890abcdef123456"
+_NORMAL_AFTER="def1234567890abcdef1234567890abcdef123456"
+_ZERO_SHA="0000000000000000000000000000000000000000"
+
+_stub_dir=""
+_output_file=""
+
+setup_env() {
+  _stub_dir=$(mktemp -d)
+  _output_file=$(mktemp)
+  export GITHUB_OUTPUT="$_output_file"
+  export PATH="$_stub_dir:$PATH"
+}
+
+cleanup_env() {
+  rm -rf "$_stub_dir"
+  rm -f "$_output_file"
+}
+
+make_git_stub() {
+  local _stub_output="$1"
+  cat > "$_stub_dir/git" << STUB
+#!/usr/bin/env bash
+echo "${_stub_output}"
+STUB
+  chmod +x "$_stub_dir/git"
+}
+
+run_script() {
+  bash "$_SCRIPT_PATH"
+}
+
+# ─── Tests ──────────────────────────────────────────────────────────────────
+
+Describe 'get-changed-files.sh'
+  BeforeEach 'setup_env'
+  AfterEach 'cleanup_env'
+
+  Describe 'When: 通常のSHAと変更ファイルがある'
+    Describe 'Then: filesとcountをGITHUB_OUTPUTに書き出す'
+      It "T-gcf-nor-01: 正常SHA + ファイルあり → files/count出力"
+        make_git_stub "src/main.ts"
+        export BEFORE_SHA="$_NORMAL_BEFORE"
+        export AFTER_SHA="$_NORMAL_AFTER"
+        export PATTERN=""
+        When call run_script
+        The contents of file "$_output_file" should include "files<<EOF"
+        The status should equal 0
+      End
+    End
+  End
+
+  Describe 'When: patternが指定されている'
+    Describe 'Then: フィルターされたファイルのみ出力する'
+      It "T-gcf-nor-02: PATTERN=*.ts → git diffにpathspecが渡され出力される"
+        make_git_stub "src/main.ts"
+        export BEFORE_SHA="$_NORMAL_BEFORE"
+        export AFTER_SHA="$_NORMAL_AFTER"
+        export PATTERN="*.ts"
+        When call run_script
+        The contents of file "$_output_file" should include "src/main.ts"
+        The status should equal 0
+      End
+    End
+  End
+
+  Describe 'When: patternが空（デフォルト）'
+    Describe 'Then: 全ファイルを出力する'
+      It "T-gcf-nor-03: PATTERN空 + 2ファイル → count=2"
+        make_git_stub "$(printf 'src/a.ts\nsrc/b.ts')"
+        export BEFORE_SHA="$_NORMAL_BEFORE"
+        export AFTER_SHA="$_NORMAL_AFTER"
+        export PATTERN=""
+        When call run_script
+        The contents of file "$_output_file" should include "count=2"
+        The status should equal 0
+      End
+    End
+  End
+
+  Describe 'When: BEFORE_SHAがゼロSHA（新ブランチpush）'
+    Describe 'Then: empty-treeと差分を取り正常動作する'
+      It "T-gcf-edg-01: ゼロSHA → empty-treeでdiff実行、status=0"
+        make_git_stub "src/new-file.ts"
+        export BEFORE_SHA="$_ZERO_SHA"
+        export AFTER_SHA="$_NORMAL_AFTER"
+        export PATTERN=""
+        When call run_script
+        The contents of file "$_output_file" should include "files<<EOF"
+        The status should equal 0
+      End
+    End
+  End
+
+  Describe 'When: BEFORE_SHAが未設定'
+    Describe 'Then: エラー終了する'
+      It "T-gcf-err-01: BEFORE_SHA未設定 → status=1"
+        make_git_stub ""
+        unset BEFORE_SHA
+        export AFTER_SHA="$_NORMAL_AFTER"
+        export PATTERN=""
+        When call run_script
+        The status should equal 1
+      End
+    End
+  End
+End

--- a/.github/actions/ca-get-changed-files/scripts/_libs/__tests__/unit/filter.unit.spec.sh
+++ b/.github/actions/ca-get-changed-files/scripts/_libs/__tests__/unit/filter.unit.spec.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# src: .github/actions/ca-get-changed-files/scripts/_libs/__tests__/unit/filter.unit.spec.sh
+# @(#) : filter.lib.sh ユニットテスト
+#
+# Copyright (c) 2026- atsushifx <atsushifx@gmail.com>
+# MIT License
+# shellcheck shell=bash
+
+Include "${SHELLSPEC_PROJECT_ROOT}/.github/actions/ca-get-changed-files/scripts/_libs/filter.lib.sh"
+
+# ─── Internal Helpers ───────────────────────────────────────────────────────
+
+_NORMAL_SHA="abc1234567890abcdef1234567890abcdef123456"
+_ZERO_SHA="0000000000000000000000000000000000000000"
+_EMPTY_TREE="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+_SHORT_ZEROS="0000000"
+
+_output_file=""
+
+setup_output_file() {
+  _output_file=$(mktemp)
+  export GITHUB_OUTPUT="$_output_file"
+}
+
+cleanup_output_file() {
+  rm -f "$_output_file"
+}
+
+check_single_line_output() {
+  write_multiline_output "files" "src/main.ts"
+  cat "$GITHUB_OUTPUT"
+}
+
+check_multiline_output() {
+  write_multiline_output "files" "$(printf 'src/a.ts\nsrc/b.ts')"
+  cat "$GITHUB_OUTPUT"
+}
+
+check_zero_value_output() {
+  write_multiline_output "count" "0"
+  cat "$GITHUB_OUTPUT"
+}
+
+# ─── Tests ──────────────────────────────────────────────────────────────────
+
+Describe 'resolve_before_sha'
+  Describe 'When: 正常なSHAが入力された'
+    Describe 'Then: そのまま返す'
+      It "T-rsl-nor-01: 40文字の正常SHA → そのまま返す"
+        When call resolve_before_sha "$_NORMAL_SHA"
+        The output should equal "$_NORMAL_SHA"
+        The status should equal 0
+      End
+    End
+  End
+
+  Describe 'When: ゼロSHAが入力された'
+    Describe 'Then: empty-tree SHAを返す'
+      It "T-rsl-zer-01: 40桁のゼロ → empty-tree SHAを返す"
+        When call resolve_before_sha "$_ZERO_SHA"
+        The output should equal "$_EMPTY_TREE"
+        The status should equal 0
+      End
+    End
+  End
+
+  Describe 'When: エッジケースの入力'
+    Describe 'Then: 空文字はempty-tree SHAを返す'
+      It "T-rsl-edg-01: 空文字 → empty-tree SHAを返す"
+        When call resolve_before_sha ""
+        The output should equal "$_EMPTY_TREE"
+        The status should equal 0
+      End
+    End
+
+    Describe 'Then: 短いゼロ列はそのまま返す'
+      It "T-rsl-edg-02: 7桁のゼロ → そのまま返す（40桁のみフォールバック）"
+        When call resolve_before_sha "$_SHORT_ZEROS"
+        The output should equal "$_SHORT_ZEROS"
+        The status should equal 0
+      End
+    End
+  End
+End
+
+Describe 'write_multiline_output'
+  BeforeEach 'setup_output_file'
+  AfterEach 'cleanup_output_file'
+
+  Describe 'When: 単一行の値を書き出す'
+    Describe 'Then: multiline EOF形式で出力される'
+      It "T-wrt-nor-01: key=files, value=src/main.ts → files<<EOF形式"
+        When call check_single_line_output
+        The output should equal "$(printf 'files<<EOF\nsrc/main.ts\nEOF')"
+        The status should equal 0
+      End
+    End
+  End
+
+  Describe 'When: 複数行の値を書き出す'
+    Describe 'Then: 全行を含むEOF形式で出力される'
+      It "T-wrt-nor-02: 複数行 → 全行含む形式で出力"
+        When call check_multiline_output
+        The output should equal "$(printf 'files<<EOF\nsrc/a.ts\nsrc/b.ts\nEOF')"
+        The status should equal 0
+      End
+    End
+  End
+
+  Describe 'When: 数値の0を書き出す'
+    Describe 'Then: count<<EOF形式で出力される'
+      It "T-wrt-edg-01: value=0 → count<<EOF\n0\nEOF"
+        When call check_zero_value_output
+        The output should equal "$(printf 'count<<EOF\n0\nEOF')"
+        The status should equal 0
+      End
+    End
+  End
+End

--- a/.github/actions/ca-get-changed-files/scripts/_libs/filter.lib.sh
+++ b/.github/actions/ca-get-changed-files/scripts/_libs/filter.lib.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# src: .github/actions/ca-get-changed-files/scripts/_libs/filter.lib.sh
+# @(#) : SHA解決とGITHUB_OUTPUT書き出しユーティリティ
+#
+# Copyright (c) 2026- atsushifx <atsushifx@gmail.com>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+# shellcheck shell=bash
+
+[ -n "${FILTER_LIB_LOADED:-}" ] && return 0
+FILTER_LIB_LOADED=1
+
+resolve_before_sha() {
+  local _sha="${1:-}"
+  local _empty_tree="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+  if [[ -z "$_sha" ]] || [[ "$_sha" =~ ^0{40}$ ]]; then
+    echo "$_empty_tree"
+  else
+    echo "$_sha"
+  fi
+}
+
+write_multiline_output() {
+  local _key="$1"
+  local _value="$2"
+  printf '%s<<EOF\n%s\nEOF\n' "$_key" "$_value" >> "${GITHUB_OUTPUT:-/dev/null}"
+}

--- a/.github/actions/ca-get-changed-files/scripts/get-changed-files.sh
+++ b/.github/actions/ca-get-changed-files/scripts/get-changed-files.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# src: .github/actions/ca-get-changed-files/scripts/get-changed-files.sh
+# @(#) : pushイベント前後の変更ファイル一覧を取得する
+#
+# Copyright (c) 2026- atsushifx <atsushifx@gmail.com>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+# shellcheck shell=bash
+
+set -euo pipefail
+
+SCRIPT_DIR="${BASH_SOURCE[0]%/*}"
+# shellcheck source=/dev/null
+. "${SCRIPT_DIR}/_libs/filter.lib.sh"
+
+main() {
+  local _before_sha="${BEFORE_SHA:-}"
+  local _after_sha="${AFTER_SHA:-}"
+  local _pattern="${PATTERN:-}"
+
+  [[ -z "$_before_sha" ]] && { echo "::error::BEFORE_SHA is required" >&2; return 1; }
+  [[ -z "$_after_sha" ]] && { echo "::error::AFTER_SHA is required" >&2; return 1; }
+
+  local _before
+  _before=$(resolve_before_sha "$_before_sha")
+
+  local _files
+  if [[ -n "$_pattern" ]]; then
+    _files=$(git diff --name-only --diff-filter=ACMR "$_before" "$_after_sha" -- "$_pattern")
+  else
+    _files=$(git diff --name-only --diff-filter=ACMR "$_before" "$_after_sha")
+  fi
+
+  local _count=0
+  if [[ -n "$_files" ]]; then
+    _count=$(echo "$_files" | grep -c .)
+  fi
+
+  write_multiline_output "files" "$_files"
+  echo "count=${_count}" >> "${GITHUB_OUTPUT:-/dev/null}"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+  exit $?
+fi

--- a/.github/workflows/_tests_ca_composite-actions.yml
+++ b/.github/workflows/_tests_ca_composite-actions.yml
@@ -101,6 +101,124 @@ jobs:
           echo "ls-lint version: ${_version}"
           echo "version=${_version}" >> "${GITHUB_OUTPUT}"
 
+  test-get-changed-files:
+    name: Test ca-get-changed-files
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs:
+      - setup-foundation
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        id: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Prepare test diff (add temporary file and commit)
+        id: prepare-diff
+        if: steps.checkout.outcome == 'success'
+        run: |
+          git config user.email "ci-test@example.com"
+          git config user.name "CI Test"
+          _before_sha=$(git rev-parse HEAD)
+          mkdir temp
+          echo "ci-test" > temp/ci-test-changed-files.txt
+          git add -f temp/ci-test-changed-files.txt
+          git commit -m "ci-test: temporary file for ca-get-changed-files test"
+          _after_sha=$(git rev-parse HEAD)
+          {
+            echo "before-sha=${_before_sha}"
+            echo "after-sha=${_after_sha}"
+            echo "test-file=temp/ci-test-changed-files.txt"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Test ca-get-changed-files (no pattern)
+        id: test-changed-files
+        if: steps.prepare-diff.outcome == 'success'
+        uses: ./.github/actions/ca-get-changed-files
+        with:
+          before-sha: ${{ steps.prepare-diff.outputs.before-sha }}
+          after-sha: ${{ steps.prepare-diff.outputs.after-sha }}
+
+      - name: Test ca-get-changed-files (pattern matches test file)
+        id: test-changed-files-pattern-match
+        if: steps.prepare-diff.outcome == 'success'
+        uses: ./.github/actions/ca-get-changed-files
+        with:
+          before-sha: ${{ steps.prepare-diff.outputs.before-sha }}
+          after-sha: ${{ steps.prepare-diff.outputs.after-sha }}
+          pattern: "*.txt"
+
+      - name: Test ca-get-changed-files (pattern does not match)
+        id: test-changed-files-pattern-nomatch
+        if: steps.prepare-diff.outcome == 'success'
+        uses: ./.github/actions/ca-get-changed-files
+        with:
+          before-sha: ${{ steps.prepare-diff.outputs.before-sha }}
+          after-sha: ${{ steps.prepare-diff.outputs.after-sha }}
+          pattern: "*.yml"
+
+      - name: Verify outputs
+        id: verify
+        if: steps.test-changed-files.outcome == 'success'
+        env:
+          TEST_FILE: ${{ steps.prepare-diff.outputs.test-file }}
+          FILES_ALL: ${{ steps.test-changed-files.outputs.files }}
+          COUNT_ALL: ${{ steps.test-changed-files.outputs.count }}
+          FILES_TXT: ${{ steps.test-changed-files-pattern-match.outputs.files }}
+          COUNT_TXT: ${{ steps.test-changed-files-pattern-match.outputs.count }}
+          FILES_YML: ${{ steps.test-changed-files-pattern-nomatch.outputs.files }}
+          COUNT_YML: ${{ steps.test-changed-files-pattern-nomatch.outputs.count }}
+        run: |
+          _failed=0
+
+          echo "=== no-pattern result ==="
+          echo "count: ${COUNT_ALL}"
+          echo "files: ${FILES_ALL}"
+
+          echo "=== pattern=*.txt result ==="
+          echo "count: ${COUNT_TXT}"
+          echo "files: ${FILES_TXT}"
+
+          echo "=== pattern=*.yml result ==="
+          echo "count: ${COUNT_YML}"
+          echo "files: ${FILES_YML}"
+
+          # no-pattern: test file must be detected
+          if [ "${COUNT_ALL}" -lt 1 ]; then
+            echo "::error::[no-pattern] Expected count >= 1, got: ${COUNT_ALL}"
+            _failed=1
+          fi
+          if ! echo "${FILES_ALL}" | grep -qF "${TEST_FILE}"; then
+            echo "::error::[no-pattern] Expected '${TEST_FILE}' in files, got: ${FILES_ALL}"
+            _failed=1
+          fi
+
+          # pattern=*.txt: test file must be detected
+          if [ "${COUNT_TXT}" -lt 1 ]; then
+            echo "::error::[pattern=*.txt] Expected count >= 1, got: ${COUNT_TXT}"
+            _failed=1
+          fi
+          if ! echo "${FILES_TXT}" | grep -qF "${TEST_FILE}"; then
+            echo "::error::[pattern=*.txt] Expected '${TEST_FILE}' in files, got: ${FILES_TXT}"
+            _failed=1
+          fi
+
+          # pattern=*.yml: test file must NOT appear (no yml changed)
+          if echo "${FILES_YML}" | grep -qF "${TEST_FILE}"; then
+            echo "::error::[pattern=*.yml] '${TEST_FILE}' should not appear, got: ${FILES_YML}"
+            _failed=1
+          fi
+
+          exit "${_failed}"
+
+      - name: Cleanup test diff (reset temporary commit)
+        if: steps.prepare-diff.outcome == 'success'
+        run: git reset --hard HEAD~1
+
   summary:
     name: Test Summary
     runs-on: ubuntu-latest
@@ -110,6 +228,7 @@ jobs:
       - setup-foundation
       - test-setup-tool
       - test-setup-repo
+      - test-get-changed-files
     permissions:
       contents: read
     steps:
@@ -118,6 +237,7 @@ jobs:
           RESULT_FOUNDATION: ${{ needs.setup-foundation.result }}
           RESULT_SETUP_TOOL: ${{ needs.test-setup-tool.result }}
           RESULT_SETUP_REPO: ${{ needs.test-setup-repo.result }}
+          RESULT_GET_CHANGED_FILES: ${{ needs.test-get-changed-files.result }}
         run: |
           _failed=0
 
@@ -130,13 +250,15 @@ jobs:
             echo ""
             echo "| Job | Result |"
             echo "| --- | ------ |"
-            echo "| setup-foundation | $(_status "${RESULT_FOUNDATION}") |"
-            echo "| test-setup-tool  | $(_status "${RESULT_SETUP_TOOL}") |"
-            echo "| test-setup-repo  | $(_status "${RESULT_SETUP_REPO}") |"
+            echo "| setup-foundation        | $(_status "${RESULT_FOUNDATION}") |"
+            echo "| test-setup-tool         | $(_status "${RESULT_SETUP_TOOL}") |"
+            echo "| test-setup-repo         | $(_status "${RESULT_SETUP_REPO}") |"
+            echo "| test-get-changed-files  | $(_status "${RESULT_GET_CHANGED_FILES}") |"
           } >> "${GITHUB_STEP_SUMMARY}"
 
           [ "${RESULT_FOUNDATION}" = "success" ] || _failed=1
           [ "${RESULT_SETUP_TOOL}" = "success" ] || _failed=1
           [ "${RESULT_SETUP_REPO}" = "success" ] || _failed=1
+          [ "${RESULT_GET_CHANGED_FILES}" = "success" ] || _failed=1
 
           exit "${_failed}"

--- a/.github/workflows/ci-publish-docs.yml
+++ b/.github/workflows/ci-publish-docs.yml
@@ -43,7 +43,7 @@ jobs:
           persist-credentials: false
 
       - name: Validate environment
-        uses: aglabo/ci-platform/.github/actions/ca-validate-environment@4044729d57bc3a119dc4b53eca9fe37a5dfad39d # v0.3.0
+        uses: aglabo/ci-platform/.github/actions/ca-validate-environment@91ec746f34b7e3c1ed547f66889dfb4b0e03c7dd # v0.3.1
         with:
           actions-type: read
 
@@ -102,7 +102,7 @@ jobs:
           persist-credentials: false
 
       - name: Validate environment
-        uses: aglabo/ci-platform/.github/actions/ca-validate-environment@4044729d57bc3a119dc4b53eca9fe37a5dfad39d # v0.3.0
+        uses: aglabo/ci-platform/.github/actions/ca-validate-environment@91ec746f34b7e3c1ed547f66889dfb4b0e03c7dd # v0.3.1
         with:
           actions-type: read
 

--- a/.github/workflows/ci-scan-secrets.yml
+++ b/.github/workflows/ci-scan-secrets.yml
@@ -28,4 +28,4 @@ jobs:
     name: Betterleaks Secret Scan
     permissions:
       contents: read
-    uses: aglabo/ci-platform/.github/workflows/ru-scan-betterleaks.yml@4044729d57bc3a119dc4b53eca9fe37a5dfad39d # v0.3.0
+    uses: aglabo/ci-platform/.github/workflows/ru-scan-betterleaks.yml@91ec746f34b7e3c1ed547f66889dfb4b0e03c7dd # v0.3.1

--- a/.github/workflows/ci-workflows-qa.yml
+++ b/.github/workflows/ci-workflows-qa.yml
@@ -32,10 +32,10 @@ jobs:
     name: Actionlint
     permissions:
       contents: read
-    uses: aglabo/ci-platform/.github/workflows/ru-qa-actionlint.yml@4044729d57bc3a119dc4b53eca9fe37a5dfad39d # v0.3.0
+    uses: aglabo/ci-platform/.github/workflows/ru-qa-actionlint.yml@91ec746f34b7e3c1ed547f66889dfb4b0e03c7dd # v0.3.1
 
   ghalint:
     name: Ghalint
     permissions:
       contents: read
-    uses: aglabo/ci-platform/.github/workflows/ru-qa-ghalint.yml@4044729d57bc3a119dc4b53eca9fe37a5dfad39d # v0.3.0
+    uses: aglabo/ci-platform/.github/workflows/ru-qa-ghalint.yml@91ec746f34b7e3c1ed547f66889dfb4b0e03c7dd # v0.3.1

--- a/.github/workflows/ru-qa-actionlint.yml
+++ b/.github/workflows/ru-qa-actionlint.yml
@@ -44,14 +44,14 @@ jobs:
       - name: Validate environment
         id: env-validation
         if: steps.target-checkout.outcome == 'success'
-        uses: aglabo/ci-platform/.github/actions/validate-environment@6988a3ea6c52c239c87369327d8b8318298cfd8f # v0.2.0
+        uses: aglabo/ci-platform/.github/actions/validate-environment@91ec746f34b7e3c1ed547f66889dfb4b0e03c7dd # v0.3.1
         with:
           actions-type: read
 
       - name: Install actionlint
         id: tool-install
         if: steps.env-validation.outcome == 'success'
-        uses: aglabo/ci-platform/.github/actions/setup-tool@6988a3ea6c52c239c87369327d8b8318298cfd8f # v0.2.0
+        uses: aglabo/ci-platform/.github/actions/setup-tool@91ec746f34b7e3c1ed547f66889dfb4b0e03c7dd # v0.3.1
         with:
           repo: rhysd/actionlint
           tool-version: ${{ inputs.actionlint-version }}

--- a/.github/workflows/ru-qa-ghalint.yml
+++ b/.github/workflows/ru-qa-ghalint.yml
@@ -42,14 +42,14 @@ jobs:
       - name: Validate environment
         id: env-validation
         if: steps.target-checkout.outcome == 'success'
-        uses: aglabo/ci-platform/.github/actions/validate-environment@2ac45debcb9c2902597abda02bcce3e6ff0121f0 # v0.2.1
+        uses: aglabo/ci-platform/.github/actions/validate-environment@91ec746f34b7e3c1ed547f66889dfb4b0e03c7dd # v0.3.1
         with:
           actions-type: read
 
       - name: Install ghalint
         id: tool-install
         if: steps.env-validation.outcome == 'success'
-        uses: aglabo/ci-platform/.github/actions/setup-tool@2ac45debcb9c2902597abda02bcce3e6ff0121f0 # v0.2.1
+        uses: aglabo/ci-platform/.github/actions/setup-tool@91ec746f34b7e3c1ed547f66889dfb4b0e03c7dd # v0.3.1
         with:
           repo: suzuki-shunsuke/ghalint
           tool-version: ${{ inputs.ghalint-version }}

--- a/.github/workflows/ru-scan-betterleaks.yml
+++ b/.github/workflows/ru-scan-betterleaks.yml
@@ -47,14 +47,14 @@ jobs:
 
       - name: Validate environment
         id: env-validation
-        uses: aglabo/ci-platform/.github/actions/validate-environment@2ac45debcb9c2902597abda02bcce3e6ff0121f0 # v0.2.1
+        uses: aglabo/ci-platform/.github/actions/validate-environment@91ec746f34b7e3c1ed547f66889dfb4b0e03c7dd # v0.3.1
         with:
           actions-type: read
 
       - name: Install betterleaks
         id: tool-install
         if: steps.env-validation.outcome == 'success'
-        uses: aglabo/ci-platform/.github/actions/setup-tool@2ac45debcb9c2902597abda02bcce3e6ff0121f0 # v0.2.1
+        uses: aglabo/ci-platform/.github/actions/setup-tool@91ec746f34b7e3c1ed547f66889dfb4b0e03c7dd # v0.3.1
         with:
           repo: betterleaks/betterleaks
           tool-version: ${{ inputs.betterleaks-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,50 @@
 ---
 title: "ci-platform Change Log"
-version: "0.3.0"
-date: 2026-06-21
+version: "0.3.1"
+date: 2026-06-22
 tags:
   - release
   - composite-actions
-  - reusable-workflows
   - ci-platform
 summary: >
-  v0.3.0 unifies composite action and reusable workflow naming conventions,
-  adds the ca-setup-repo composite action, introduces a Docusaurus documentation
-  publishing pipeline, and pins all caller workflows to external repository references.
+  v0.3.1 adds the ca-get-changed-files composite action for detecting changed files
+  between commits in push events.
+---
+
+<!-- textlint-disable
+  ja-technical-writing/sentence-length,
+  ja-technical-writing/max-comma
+  -->
+
+## [0.3.1] - 2026-06-22
+
+### Overview
+
+This release adds `ca-get-changed-files`, a composite action that detects changed files
+between before/after commits in push events.
+
+It supports glob pattern filtering and outputs the changed file list and count,
+enabling downstream jobs and steps to use them for conditional branching or file processing.
+
+---
+
+### Added
+
+#### Composite Actions
+
+- `ca-get-changed-files`: Detects changed files between commits in push events.
+  Accepts an optional `pattern` input for glob filtering, and exposes `before-sha` / `after-sha`
+  inputs to override the default commit SHAs (`github.event.before` / `github.sha`).
+  Outputs `files` (newline-separated paths) and `count` (number of changed files).
+  Requires `actions/checkout` with `fetch-depth: 0`.
+
+---
+
+### Notes
+
+- `ca-get-changed-files` behavior is verified by integration tests covering
+  no-pattern, pattern-match, and pattern-no-match scenarios.
+
 ---
 
 ## [0.3.0] - 2026-06-21

--- a/Release-Note.md
+++ b/Release-Note.md
@@ -1,0 +1,69 @@
+---
+title: "ci-platform Release Notes v0.3.1"
+version: "0.3.1"
+date: 2026-06-22
+tags:
+  - release
+  - composite-actions
+summary: >
+  v0.3.1 では、push イベントでコミット間の変更ファイルを検出する
+  ca-get-changed-files コンポジットアクションを追加しました。
+---
+
+## [0.3.1] - 2026-06-22
+
+### Overview
+
+このリリースでは、`ca-get-changed-files` コンポジットアクションを新たに追加しました。
+
+push イベントの before/after コミット間で変更されたファイルを取得し、
+glob パターンによるフィルタリングに対応します。
+変更ファイルの一覧と件数を出力として提供するため、
+後続のジョブやステップで条件分岐・ファイル処理に活用できます。
+
+---
+
+### Added
+
+#### Composite Actions
+
+- `ca-get-changed-files`: push イベントで変更されたファイルを検出するコンポジットアクション。
+
+  入力パラメータ:
+
+  | パラメータ   | 必須 | デフォルト            | 説明                                 |
+  | ------------ | ---- | --------------------- | ------------------------------------ |
+  | `pattern`    | 任意 | `""` (全ファイル)     | 変更ファイルを絞り込む glob パターン |
+  | `before-sha` | 任意 | `github.event.before` | 比較元コミット SHA                   |
+  | `after-sha`  | 任意 | `github.sha`          | 比較先コミット SHA                   |
+
+  出力:
+
+  | 出力    | 説明                                 |
+  | ------- | ------------------------------------ |
+  | `files` | 変更ファイルのパス一覧（改行区切り） |
+  | `count` | 変更ファイルの件数                   |
+
+  前提条件: `actions/checkout` で `fetch-depth: 0` の設定が必須です。
+
+  使用例:
+
+  ```yaml
+  - uses: actions/checkout@v4
+    with:
+      fetch-depth: 0
+
+  - uses: aglabo/ci-platform/.github/actions/ca-get-changed-files@v0.3.1
+    id: changed
+    with:
+      pattern: "src/**/*.ts"
+
+  - run: echo "Changed files: ${{ steps.changed.outputs.files }}"
+  ```
+
+---
+
+### Notes
+
+- `ca-get-changed-files` はパターンなし・マッチあり・マッチなしのシナリオを含む
+  インテグレーションテストで動作を検証済みです。

--- a/docs/.deckrd/composite-action/get-changed-files/implementation/implementation.md
+++ b/docs/.deckrd/composite-action/get-changed-files/implementation/implementation.md
@@ -1,0 +1,59 @@
+---
+id: IMPL
+module: composite-action/get-changed-files
+status: approved
+refs: [SPEC]
+---
+
+# Implementation: ca-get-changed-files
+
+## File Structure
+
+```
+.github/actions/ca-get-changed-files/
+├── action.yml
+└── scripts/
+    ├── get-changed-files.sh
+    ├── _libs/
+    │   └── filter.lib.sh
+    └── __tests__/
+        ├── unit/
+        │   └── filter.unit.spec.sh
+        └── functional/
+            └── get-changed-files.functional.spec.sh
+```
+
+## Implementation Notes
+
+### action.yml
+
+- `runs.using: composite`
+- SHA（BEFORE_SHA/AFTER_SHA）はenv:セクションで`github.event.before`/`github.sha`から注入
+- inputは`pattern`のみ
+
+### get-changed-files.sh
+
+- ヘッダー: `#!/usr/bin/env bash` + `# src:` + `# @(#):` + MIT + `# shellcheck shell=bash`
+- `set -euo pipefail`
+- `SCRIPT_DIR="${BASH_SOURCE[0]%/*}"`
+- `_libs/filter.lib.sh` をsource
+- main()関数にロジックを集約
+- `[[ "${BASH_SOURCE[0]}" == "${0}" ]]` でmain呼び出し
+
+### filter.lib.sh
+
+- guard pattern: `[ -n "${FILTER_LIB_LOADED:-}" ] && return 0`
+- `resolve_before_sha()`: ゼロSHA→empty-tree変換
+- `write_multiline_output()`: GITHUB_OUTPUT multiline書き出し
+
+## Commit Linkage
+
+各実装ファイルは以下のcommit参照を含める:
+
+```
+ci(actions): add ca-get-changed-files composite action
+
+Implements: IMPL-001
+Spec: SPEC-001
+Req: REQ-001
+```

--- a/docs/.deckrd/composite-action/get-changed-files/requirements/requirements.md
+++ b/docs/.deckrd/composite-action/get-changed-files/requirements/requirements.md
@@ -1,0 +1,56 @@
+---
+id: REQ
+module: composite-action/get-changed-files
+status: approved
+---
+
+# Requirements: ca-get-changed-files
+
+## Functional Requirements
+
+### REQ-F-001: SHA内部取得
+
+- pushイベントの `github.event.before`（開始SHA）と `github.sha`（終了SHA）をaction内部で取得する
+- 外部inputとしてSHAを公開しない（push専用として完全内部化）
+
+### REQ-F-002: ゼロSHAフォールバック
+
+- `before` SHAが40桁のゼロ（新ブランチpush時）の場合、git empty-tree SHA（`4b825dc642cb6eb9a060e54bf8d69288fbee4904`）を使用する
+
+### REQ-F-003: 変更ファイル取得
+
+- `git diff --name-only --diff-filter=ACMR` で変更ファイルを取得する
+- diff-filter: A（追加）、C（コピー）、M（変更）、R（リネーム）のみ対象
+
+### REQ-F-004: globパターンフィルター
+
+- `pattern` inputでgit pathspec globを指定できる（例: `*.ts`, `src/**/*.sh`）
+- デフォルト値は空文字（全ファイル対象）
+- 空のとき `--` pathspec 引数を付けない
+
+### REQ-F-005: files output
+
+- 変更ファイルのパス一覧を改行区切りで `files` outputに書き出す
+- `$GITHUB_OUTPUT` のmultiline形式（`files<<EOF…EOF`）で出力する
+
+### REQ-F-006: count output
+
+- 変更ファイル数を整数で `count` outputに書き出す
+
+## Non-Functional Requirements
+
+### REQ-NF-001: fetch-depth制約
+
+- 正常動作には呼び出し元での `fetch-depth: 0` 設定が必須
+- この制約をaction.ymlのdescriptionに明記する
+
+### REQ-NF-002: 最小権限
+
+- 必要な権限は `contents: read` のみ
+
+## Constraints
+
+### REQ-C-001: pushイベント専用
+
+- このactionはpushイベントでのみ正常動作する
+- PRイベント等では `github.event.before` が存在しない場合がある

--- a/docs/.deckrd/composite-action/get-changed-files/specifications/specifications.md
+++ b/docs/.deckrd/composite-action/get-changed-files/specifications/specifications.md
@@ -1,0 +1,86 @@
+---
+id: SPEC
+module: composite-action/get-changed-files
+status: approved
+refs: [REQ-F-001, REQ-F-002, REQ-F-003, REQ-F-004, REQ-F-005, REQ-F-006]
+---
+
+# Specifications: ca-get-changed-files
+
+## Action Interface
+
+### action.yml
+
+```yaml
+name: "get-changed-files"
+description: |
+  Get changed files between push before/after commits.
+  IMPORTANT: Requires fetch-depth: 0 in actions/checkout.
+
+inputs:
+  pattern:
+    description: "Git pathspec glob filter (e.g. '*.ts', 'src/**/*.sh'). Empty = all files."
+    required: false
+    default: ""
+
+outputs:
+  files:
+    description: "Newline-separated list of changed file paths"
+    value: ${{ steps.get-changed-files.outputs.files }}
+  count:
+    description: "Number of changed files"
+    value: ${{ steps.get-changed-files.outputs.count }}
+
+runs:
+  using: composite
+  steps:
+    - name: Get changed files
+      id: get-changed-files
+      shell: bash
+      run: bash "${{ github.action_path }}/scripts/get-changed-files.sh"
+      env:
+        BEFORE_SHA: ${{ github.event.before }}
+        AFTER_SHA: ${{ github.sha }}
+        PATTERN: ${{ inputs.pattern }}
+```
+
+## Script Specifications
+
+### get-changed-files.sh
+
+**入力（環境変数）:**
+
+- `BEFORE_SHA`: pushイベント前のSHA（`github.event.before`から注入）
+- `AFTER_SHA`: pushイベント後のSHA（`github.sha`から注入）
+- `PATTERN`: globパターン（空可）
+
+**処理フロー:**
+
+1. `BEFORE_SHA` / `AFTER_SHA` の存在確認
+2. `resolve_before_sha()`: ゼロSHAをempty-treeに置換
+3. PATTERNが空でなければ pathspec引数を構築
+4. `git diff --name-only --diff-filter=ACMR $BEFORE $AFTER [-- $PATTERN]` を実行
+5. `write_multiline_output "files" "$result"` で GITHUB_OUTPUT に書き出し
+6. `echo "count=$count" >> $GITHUB_OUTPUT` でcount書き出し
+
+### filter.lib.sh（ライブラリ関数）
+
+#### resolve_before_sha(sha)
+
+- 入力: SHA文字列
+- 出力: 解決済みSHA（ゼロSHAの場合はempty-tree SHA）
+- 空SHAの場合もempty-treeを返す
+
+#### write_multiline_output(key, value)
+
+- `$GITHUB_OUTPUT` にmultiline形式で書き出す
+- フォーマット: `key<<EOF\nvalue\nEOF\n`
+- fallback: `${GITHUB_OUTPUT:-/dev/null}`
+
+## Test Scope
+
+| spec                   | test type  | 対象                  |
+| ---------------------- | ---------- | --------------------- |
+| resolve_before_sha     | unit       | 正常SHA/ゼロSHA/空SHA |
+| write_multiline_output | unit       | 単行/複数行/空値      |
+| get-changed-files.sh   | functional | 全体フロー            |

--- a/docs/.deckrd/composite-action/get-changed-files/tasks/tasks.md
+++ b/docs/.deckrd/composite-action/get-changed-files/tasks/tasks.md
@@ -1,0 +1,71 @@
+---
+id: TASKS
+module: composite-action/get-changed-files
+status: approved
+refs: [IMPL]
+---
+
+# Tasks: ca-get-changed-files
+
+## Implementation Tasks
+
+### T-01: filter.lib.sh の実装（BDD）
+
+**対象ファイル:**
+
+- `scripts/_libs/filter.lib.sh`
+- `scripts/__tests__/unit/filter.unit.spec.sh`
+
+**テストケース:**
+
+#### resolve_before_sha()
+
+- `[nrm-01]` 正常SHA → そのまま返す
+- `[nrm-02]` ゼロSHA（40桁）→ empty-tree SHAを返す
+- `[edg-01]` 空文字 → empty-tree SHAを返す
+- `[edg-02]` 短いゼロ列 → そのまま返す（40桁のみフォールバック対象）
+
+#### write_multiline_output()
+
+- `[nrm-01]` 単行値 → `key<<EOF\nvalue\nEOF\n` 形式で出力
+- `[nrm-02]` 複数行値 → 全行を含む形式で出力
+- `[edg-01]` 空値 → `key<<EOF\n\nEOF\n` 形式で出力
+
+### T-02: get-changed-files.sh の実装（BDD）
+
+**対象ファイル:**
+
+- `scripts/get-changed-files.sh`
+- `scripts/__tests__/functional/get-changed-files.functional.spec.sh`
+
+**テストケース:**
+
+- `[nrm-01]` 正常なBEFORE/AFTER SHA → 変更ファイル一覧を出力
+- `[nrm-02]` pattern指定あり → フィルターされたファイルのみ出力
+- `[nrm-03]` pattern空（デフォルト）→ 全ファイルを出力
+- `[edg-01]` ゼロSHA → empty-treeとdiffして正常動作
+- `[err-01]` BEFORE_SHA未設定 → エラー終了
+
+### T-03: action.yml の作成
+
+**対象ファイル:**
+
+- `action.yml`
+
+**内容:** SPEC記載のaction.yml構造に従って作成（BDDサイクル対象外、ドキュメント作成）
+
+## Execution Order
+
+1. T-01: filter.lib.sh（bdd-coderで実装）
+2. T-02: get-changed-files.sh（bdd-coderで実装）
+3. T-03: action.yml（直接作成）
+
+## BDD Coder Handoff
+
+T-01, T-02はbdd-coderエージェントに委譲する。
+引き継ぎ情報:
+
+- 作業種別: 新機能追加
+- テストフレームワーク: ShellSpec
+- テストコマンド: `bash ./scripts/run-specs.sh <spec-path> --format tap --no-color`
+- プロジェクトルート: `/c/Users/atsushifx/workspaces/develop/ci-platform`


### PR DESCRIPTION
## Overview

**Summary**
Merges the v0.3.1 release branch into main, adding the `ca-get-changed-files` composite action and pinning all workflow SHAs to v0.3.1.

**Background / Motivation**
CI workflows lacked a standard way to detect changed files between commits.
`ca-get-changed-files` fills this gap by diffing before/after SHAs on push events and exposing the results as action outputs.
All reusable workflow references are also bumped to v0.3.1 to stay consistent.

## Changes

### Core Changes

- `.github/actions/ca-get-changed-files/action.yml` — new composite action; inputs: `before-sha`, `after-sha`, `pattern`; outputs: `files`, `count`
- `scripts/get-changed-files.sh` — detects changed files via `git diff --name-only --diff-filter=ACMR`
- `scripts/_libs/filter.lib.sh` — utilities: `resolve_before_sha`, `write_multiline_output`
- Workflow SHA updates (v0.2.x / v0.3.0 → v0.3.1): `ci-publish-docs.yml`, `ci-scan-secrets.yml`, `ci-workflows-qa.yml`, `ru-qa-actionlint.yml`, `ru-qa-ghalint.yml`, `ru-scan-betterleaks.yml`

### Test Updates

- `get-changed-files.functional.spec.sh` — functional tests covering normal, edge, and error scenarios
- `filter.unit.spec.sh` — unit tests for `resolve_before_sha` and `write_multiline_output`
- `_tests_ca_composite-actions.yml` — integration test job for `ca-get-changed-files` (no filter / `*.txt` match / `*.yml` non-match)

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [x] CI/CD
- [ ] Other

## Related Issues

> Closes #95
> Closes #96

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [x] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

- `actions/checkout` with `fetch-depth: 0` is required when using `ca-get-changed-files`.
- Design documents are under `docs/.deckrd/composite-action/get-changed-files/`.