### PR TITLE
feat(ca-get-changed-files): add pull_request event support

### DIFF
--- a/.github/actions/ca-get-changed-files/action.yml
+++ b/.github/actions/ca-get-changed-files/action.yml
@@ -1,5 +1,5 @@
 # src: ./.github/actions/validate-environment/action.yml
-# @(#) : Composite: get changes files on push
+# @(#) : Composite: get changed files on push or pull_request
 #
 # Copyright (c) 2026- aglabo <https://github.com/aglabo>
 #
@@ -8,19 +8,19 @@
 
 name: "get-changed-files"
 description: |
-  Get changed files between push before/after commits using git diff.
+  Get changed files between commits using git diff.
   IMPORTANT: Requires fetch-depth: 0 in actions/checkout step.
-  Only works with push events (uses github.event.before and github.sha internally).
+  Supports push and pull_request events. For pull_request, uses base/head SHA automatically.
 
 inputs:
   before-sha:
-    description: "SHA of the commit before the push. Defaults to github.event.before (push events). Override for testing or non-push events."
+    description: "Base commit SHA. Defaults to pull_request.base.sha for PR events, github.event.before for push events."
     required: false
-    default: ${{ github.event.before }}
+    default: ""
   after-sha:
-    description: "SHA of the commit after the push. Defaults to github.sha."
+    description: "Head commit SHA. Defaults to pull_request.head.sha for PR events, github.sha for push events."
     required: false
-    default: ${{ github.sha }}
+    default: ""
   pattern:
     description: "Git pathspec glob filter (e.g. '*.ts', 'src/**/*.sh'). Empty = all files."
     required: false
@@ -37,11 +37,30 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Resolve SHA for event
+      id: resolve-sha
+      shell: bash
+      run: |
+        . "${{ github.action_path }}/scripts/_libs/filter.lib.sh"
+        if ! _result=$(resolve_sha_for_event \
+          "${{ inputs.before-sha }}" \
+          "${{ inputs.after-sha }}" \
+          "${{ github.event_name }}"); then
+          exit 1
+        fi
+        _before=$(echo "$_result" | head -n1)
+        _after=$(echo "$_result" | tail -n1)
+        echo "before_sha=${_before}" >> "$GITHUB_OUTPUT"
+        echo "after_sha=${_after}" >> "$GITHUB_OUTPUT"
+      env:
+        GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
     - name: Get changed files
       id: get-changed-files
       shell: bash
       run: bash "${{ github.action_path }}/scripts/get-changed-files.sh"
       env:
-        BEFORE_SHA: ${{ inputs.before-sha }}
-        AFTER_SHA: ${{ inputs.after-sha }}
+        BEFORE_SHA: ${{ steps.resolve-sha.outputs.before_sha }}
+        AFTER_SHA: ${{ steps.resolve-sha.outputs.after_sha }}
         PATTERN: ${{ inputs.pattern }}

--- a/.github/actions/ca-get-changed-files/scripts/__tests__/functional/get-changed-files.functional.spec.sh
+++ b/.github/actions/ca-get-changed-files/scripts/__tests__/functional/get-changed-files.functional.spec.sh
@@ -113,6 +113,7 @@ Describe 'get-changed-files.sh'
         export AFTER_SHA="$_NORMAL_AFTER"
         export PATTERN=""
         When call run_script
+        The error should include "BEFORE_SHA is required"
         The status should equal 1
       End
     End

--- a/.github/actions/ca-get-changed-files/scripts/_libs/__tests__/unit/filter.unit.spec.sh
+++ b/.github/actions/ca-get-changed-files/scripts/_libs/__tests__/unit/filter.unit.spec.sh
@@ -6,6 +6,8 @@
 # MIT License
 # shellcheck shell=bash
 
+# cspell:words aabbccddee
+
 Include "${SHELLSPEC_PROJECT_ROOT}/.github/actions/ca-get-changed-files/scripts/_libs/filter.lib.sh"
 
 # ─── Internal Helpers ───────────────────────────────────────────────────────
@@ -42,6 +44,76 @@ check_zero_value_output() {
 }
 
 # ─── Tests ──────────────────────────────────────────────────────────────────
+
+Describe 'resolve_sha_for_event'
+  _BEFORE_SHA="abc1234567890abcdef1234567890abcdef123456"
+  _AFTER_SHA="def1234567890abcdef1234567890abcdef123456"
+  _BASE_SHA="base111aabbccddee000000000000000000000000"
+  _HEAD_SHA="head222aabbccddee000000000000000000000000"
+
+  Describe 'When: workflow_dispatch イベントが渡された'
+    Describe 'Then: T-rsv-edg-01 - 引数の before/after SHA を2行で出力する'
+      It "T-rsv-edg-01: workflow_dispatch, before=abc..., after=def... → 2行出力"
+        When call resolve_sha_for_event "$_BEFORE_SHA" "$_AFTER_SHA" "workflow_dispatch"
+        The output should equal "$(printf '%s\n%s' "$_BEFORE_SHA" "$_AFTER_SHA")"
+        The status should equal 0
+      End
+    End
+  End
+
+  Describe 'When: push イベントが渡された'
+    Describe 'Then: T-rsv-nor-01 - 引数の before/after SHA を2行で出力する'
+      It "T-rsv-nor-01: push, before=abc..., after=def... → 2行出力"
+        When call resolve_sha_for_event "$_BEFORE_SHA" "$_AFTER_SHA" "push"
+        The output should equal "$(printf '%s\n%s' "$_BEFORE_SHA" "$_AFTER_SHA")"
+        The status should equal 0
+      End
+    End
+  End
+
+  Describe 'When: pull_request イベントが渡された'
+    check_pr_shas() {
+      GITHUB_BASE_SHA="$_BASE_SHA" GITHUB_HEAD_SHA="$_HEAD_SHA" \
+        resolve_sha_for_event "" "" "pull_request"
+    }
+
+    check_pr_base_empty() {
+      GITHUB_BASE_SHA="" GITHUB_HEAD_SHA="$_HEAD_SHA" \
+        resolve_sha_for_event "" "" "pull_request"
+    }
+
+    check_pr_head_empty() {
+      GITHUB_BASE_SHA="$_BASE_SHA" GITHUB_HEAD_SHA="" \
+        resolve_sha_for_event "" "" "pull_request"
+    }
+
+    Describe 'Then: T-rsv-nor-02 - GITHUB_BASE_SHA / GITHUB_HEAD_SHA を2行で出力する'
+      It "T-rsv-nor-02: pull_request, BASE=base111..., HEAD=head222... → 2行出力"
+        When call check_pr_shas
+        The output should equal "$(printf '%s\n%s' "$_BASE_SHA" "$_HEAD_SHA")"
+        The status should equal 0
+      End
+    End
+
+    Describe 'Then: T-rsv-err-01 - GITHUB_BASE_SHA が空のときエラーを返す'
+      It "T-rsv-err-01: pull_request, GITHUB_BASE_SHA="" → エラーメッセージ + status 1"
+        When call check_pr_base_empty
+        The output should equal ""
+        The error should include "pull_request event requires GITHUB_BASE_SHA and GITHUB_HEAD_SHA"
+        The status should equal 1
+      End
+    End
+
+    Describe 'Then: T-rsv-err-02 - GITHUB_HEAD_SHA が空のときエラーを返す'
+      It "T-rsv-err-02: pull_request, GITHUB_HEAD_SHA="" → エラーメッセージ + status 1"
+        When call check_pr_head_empty
+        The output should equal ""
+        The error should include "pull_request event requires GITHUB_BASE_SHA and GITHUB_HEAD_SHA"
+        The status should equal 1
+      End
+    End
+  End
+End
 
 Describe 'resolve_before_sha'
   Describe 'When: 正常なSHAが入力された'

--- a/.github/actions/ca-get-changed-files/scripts/_libs/filter.lib.sh
+++ b/.github/actions/ca-get-changed-files/scripts/_libs/filter.lib.sh
@@ -11,6 +11,21 @@
 [ -n "${FILTER_LIB_LOADED:-}" ] && return 0
 FILTER_LIB_LOADED=1
 
+resolve_sha_for_event() {
+  local _before_sha="${1:-}"
+  local _after_sha="${2:-}"
+  local _event_name="${3:-}"
+  if [[ "$_event_name" == "pull_request" ]]; then
+    if [[ -z "${GITHUB_BASE_SHA:-}" ]] || [[ -z "${GITHUB_HEAD_SHA:-}" ]]; then
+      echo "::error::pull_request event requires GITHUB_BASE_SHA and GITHUB_HEAD_SHA" >&2
+      return 1
+    fi
+    printf '%s\n%s\n' "$GITHUB_BASE_SHA" "$GITHUB_HEAD_SHA"
+  else
+    printf '%s\n%s\n' "$_before_sha" "$_after_sha"
+  fi
+}
+
 resolve_before_sha() {
   local _sha="${1:-}"
   local _empty_tree="4b825dc642cb6eb9a060e54bf8d69288fbee4904"


### PR DESCRIPTION
## Overview

**Summary**
Add `pull_request` event support to the `ca-get-changed-files` action.

**Background / Motivation**
The action previously only handled `push` events. This change extends it to support `pull_request` events by resolving the correct base/head SHAs depending on the event type.

## Changes

### Core Changes

- **`action.yml`**: Add `pull_request` event support
  - Update description to reflect both `push` and `pull_request` support
  - Change `before-sha`/`after-sha` default values to empty strings
  - Add `resolve-sha` step to resolve event-specific SHAs
  - Use `GITHUB_BASE_SHA`/`GITHUB_HEAD_SHA` for `pull_request` events
  - Use `event.before`/`github.sha` for `push` events
  - Fail fast when `resolve_sha_for_event` fails

- **`filter.lib.sh`**: Add `resolve_sha_for_event` function
  - For `pull_request` events: read `GITHUB_BASE_SHA` and `GITHUB_HEAD_SHA`
  - Output `::error::` and return 1 if either SHA is missing
  - For other events: pass through the before/after SHA arguments

### Test Updates

- **`filter.unit.spec.sh`**: Add unit tests for `resolve_sha_for_event`
  - `workflow_dispatch` event (T-rsv-edg-01)
  - `push` event normal case (T-rsv-nor-01)
  - `pull_request` event normal case (T-rsv-nor-02)
  - `pull_request` event error: `GITHUB_BASE_SHA` missing (T-rsv-err-01)
  - `pull_request` event error: `GITHUB_HEAD_SHA` missing (T-rsv-err-02)

- **`get-changed-files.functional.spec.sh`**: Add error message assertion
  - Verify error message output when `BEFORE_SHA` is not set

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

Closes #98

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

The `resolve_sha_for_event` function is added to `filter.lib.sh` to keep SHA resolution logic separate from the action entry point.
