### PR TITLE
feat(ca-get-changed-files): add explicit sha parameter support

### DIFF
--- a/.github/actions/ca-get-changed-files/scripts/_libs/__tests__/unit/filter.unit.spec.sh
+++ b/.github/actions/ca-get-changed-files/scripts/_libs/__tests__/unit/filter.unit.spec.sh
@@ -113,6 +113,88 @@ Describe 'resolve_sha_for_event'
       End
     End
   End
+
+  Describe 'When: before-sha と after-sha が両方指定された'
+    check_explicit_push() {
+      GITHUB_BASE_SHA="$_BASE_SHA" GITHUB_HEAD_SHA="$_HEAD_SHA" \
+        resolve_sha_for_event "$_BEFORE_SHA" "$_AFTER_SHA" "push"
+    }
+
+    check_explicit_pr() {
+      GITHUB_BASE_SHA="$_BASE_SHA" GITHUB_HEAD_SHA="$_HEAD_SHA" \
+        resolve_sha_for_event "$_BEFORE_SHA" "$_AFTER_SHA" "pull_request"
+    }
+
+    check_explicit_before_only_pr() {
+      GITHUB_BASE_SHA="$_BASE_SHA" GITHUB_HEAD_SHA="$_HEAD_SHA" \
+        resolve_sha_for_event "$_BEFORE_SHA" "" "pull_request"
+    }
+
+    check_explicit_after_only_pr() {
+      GITHUB_BASE_SHA="$_BASE_SHA" GITHUB_HEAD_SHA="$_HEAD_SHA" \
+        resolve_sha_for_event "" "$_AFTER_SHA" "pull_request"
+    }
+
+    check_explicit_before_only_push() {
+      resolve_sha_for_event "$_BEFORE_SHA" "" "push"
+    }
+
+    check_explicit_after_only_push() {
+      resolve_sha_for_event "" "$_AFTER_SHA" "push"
+    }
+
+    Describe 'Then: T-rsv-sha-01 - push イベントで両方指定 → 指定値を返す'
+      It "T-rsv-sha-01: push, before=abc..., after=def... → 指定値を2行出力"
+        When call check_explicit_push
+        The output should equal "$(printf '%s\n%s' "$_BEFORE_SHA" "$_AFTER_SHA")"
+        The status should equal 0
+      End
+    End
+
+    Describe 'Then: T-rsv-sha-02 - pull_request イベントで両方指定 → 指定値を優先する'
+      It "T-rsv-sha-02: pull_request, before=abc..., after=def... → 指定値を優先（GITHUB_BASE/HEAD_SHA を無視）"
+        When call check_explicit_pr
+        The output should equal "$(printf '%s\n%s' "$_BEFORE_SHA" "$_AFTER_SHA")"
+        The status should equal 0
+      End
+    End
+
+    Describe 'Then: T-rsv-sha-03 - pull_request, before のみ指定 → エラーを返す'
+      It "T-rsv-sha-03: pull_request, before=abc..., after=empty → エラーメッセージ + status 1"
+        When call check_explicit_before_only_pr
+        The output should equal ""
+        The error should include "before-sha and after-sha must both be specified or both be empty"
+        The status should equal 1
+      End
+    End
+
+    Describe 'Then: T-rsv-sha-04 - pull_request, after のみ指定 → エラーを返す'
+      It "T-rsv-sha-04: pull_request, before=empty, after=def... → エラーメッセージ + status 1"
+        When call check_explicit_after_only_pr
+        The output should equal ""
+        The error should include "before-sha and after-sha must both be specified or both be empty"
+        The status should equal 1
+      End
+    End
+
+    Describe 'Then: T-rsv-sha-05 - push, before のみ指定 → エラーを返す'
+      It "T-rsv-sha-05: push, before=abc..., after=empty → エラーメッセージ + status 1"
+        When call check_explicit_before_only_push
+        The output should equal ""
+        The error should include "before-sha and after-sha must both be specified or both be empty"
+        The status should equal 1
+      End
+    End
+
+    Describe 'Then: T-rsv-sha-06 - push, after のみ指定 → エラーを返す'
+      It "T-rsv-sha-06: push, before=empty, after=def... → エラーメッセージ + status 1"
+        When call check_explicit_after_only_push
+        The output should equal ""
+        The error should include "before-sha and after-sha must both be specified or both be empty"
+        The status should equal 1
+      End
+    End
+  End
 End
 
 Describe 'resolve_before_sha'

--- a/.github/actions/ca-get-changed-files/scripts/_libs/filter.lib.sh
+++ b/.github/actions/ca-get-changed-files/scripts/_libs/filter.lib.sh
@@ -15,6 +15,14 @@ resolve_sha_for_event() {
   local _before_sha="${1:-}"
   local _after_sha="${2:-}"
   local _event_name="${3:-}"
+  if [[ -n "$_before_sha" ]] && [[ -n "$_after_sha" ]]; then
+    printf '%s\n%s\n' "$_before_sha" "$_after_sha"
+    return 0
+  fi
+  if [[ -n "$_before_sha" ]] || [[ -n "$_after_sha" ]]; then
+    echo "::error::before-sha and after-sha must both be specified or both be empty" >&2
+    return 1
+  fi
   if [[ "$_event_name" == "pull_request" ]]; then
     if [[ -z "${GITHUB_BASE_SHA:-}" ]] || [[ -z "${GITHUB_HEAD_SHA:-}" ]]; then
       echo "::error::pull_request event requires GITHUB_BASE_SHA and GITHUB_HEAD_SHA" >&2


### PR DESCRIPTION
## Overview

**Summary**
Adds explicit `before-sha` / `after-sha` parameter support to `resolve_sha_for_event`, allowing callers to override automatic SHA resolution.

**Background / Motivation**
`resolve_sha_for_event` previously resolved SHAs based on event type (`push` / `pull_request`) only. Some CI pipelines need to specify an arbitrary SHA range regardless of event type. This change lets callers pass both SHAs explicitly; the function returns them directly without inspecting the event name. Passing only one SHA is treated as a misconfiguration and returns an error.

## Changes

### Core Changes

- `.github/actions/ca-get-changed-files/scripts/_libs/filter.lib.sh`
  - Add early-exit block at the top of `resolve_sha_for_event`
  - Both `before-sha` and `after-sha` provided → return them as-is (ignore event name)
  - Only one provided → print error to stderr and return 1

### Test Updates

- `.github/actions/ca-get-changed-files/scripts/_libs/__tests__/unit/filter.unit.spec.sh`
  - Add 6 test cases (T-rsv-sha-01 – T-rsv-sha-06)
  - Normal: both SHAs provided for `push` and `pull_request` events return the given values
  - Error: only `before-sha` or only `after-sha` provided returns status 1 with an error message

### Removed

N/A

## Change Type (optional)

- [x] Feature

## Related Issues

> N/A

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

Existing behavior (event-based SHA resolution) is unchanged. When neither parameter is supplied, the function falls through to the original event-name logic.
