### PR TITLE
fix(ca-get-changed-files): add push event support and reject unsupported events

### DIFF
--- a/.github/actions/ca-get-changed-files/action.yml
+++ b/.github/actions/ca-get-changed-files/action.yml
@@ -55,6 +55,8 @@ runs:
       env:
         GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        GITHUB_BEFORE_SHA: ${{ github.event.before }}
+        GITHUB_AFTER_SHA: ${{ github.sha }}
 
     - name: Get changed files
       id: get-changed-files

--- a/.github/actions/ca-get-changed-files/scripts/_libs/__tests__/unit/filter.unit.spec.sh
+++ b/.github/actions/ca-get-changed-files/scripts/_libs/__tests__/unit/filter.unit.spec.sh
@@ -59,6 +59,15 @@ Describe 'resolve_sha_for_event'
         The status should equal 0
       End
     End
+
+    Describe 'Then: T-rsv-edg-02 - 引数なし + 環境変数なしのときエラーを返す'
+      It "T-rsv-edg-02: workflow_dispatch, no args, no env → Unsupported event エラー + status 1"
+        When call resolve_sha_for_event "" "" "workflow_dispatch"
+        The output should equal ""
+        The error should include "Unsupported event"
+        The status should equal 1
+      End
+    End
   End
 
   Describe 'When: push イベントが渡された'
@@ -67,6 +76,47 @@ Describe 'resolve_sha_for_event'
         When call resolve_sha_for_event "$_BEFORE_SHA" "$_AFTER_SHA" "push"
         The output should equal "$(printf '%s\n%s' "$_BEFORE_SHA" "$_AFTER_SHA")"
         The status should equal 0
+      End
+    End
+
+    check_push_shas() {
+      GITHUB_BEFORE_SHA="$_BEFORE_SHA" GITHUB_AFTER_SHA="$_AFTER_SHA" \
+        resolve_sha_for_event "" "" "push"
+    }
+
+    check_push_before_empty() {
+      GITHUB_BEFORE_SHA="" GITHUB_AFTER_SHA="$_AFTER_SHA" \
+        resolve_sha_for_event "" "" "push"
+    }
+
+    check_push_after_empty() {
+      GITHUB_BEFORE_SHA="$_BEFORE_SHA" GITHUB_AFTER_SHA="" \
+        resolve_sha_for_event "" "" "push"
+    }
+
+    Describe 'Then: T-rsv-psh-01 - 環境変数から push SHA を解決する'
+      It "T-rsv-psh-01: push, GITHUB_BEFORE/AFTER_SHA 設定済み → 2行出力"
+        When call check_push_shas
+        The output should equal "$(printf '%s\n%s' "$_BEFORE_SHA" "$_AFTER_SHA")"
+        The status should equal 0
+      End
+    End
+
+    Describe 'Then: T-rsv-psh-02 - GITHUB_BEFORE_SHA が空のときエラーを返す'
+      It "T-rsv-psh-02: push, GITHUB_BEFORE_SHA="" → エラーメッセージ + status 1"
+        When call check_push_before_empty
+        The output should equal ""
+        The error should include "push event requires GITHUB_BEFORE_SHA and GITHUB_AFTER_SHA"
+        The status should equal 1
+      End
+    End
+
+    Describe 'Then: T-rsv-psh-03 - GITHUB_AFTER_SHA が空のときエラーを返す'
+      It "T-rsv-psh-03: push, GITHUB_AFTER_SHA="" → エラーメッセージ + status 1"
+        When call check_push_after_empty
+        The output should equal ""
+        The error should include "push event requires GITHUB_BEFORE_SHA and GITHUB_AFTER_SHA"
+        The status should equal 1
       End
     End
   End

--- a/.github/actions/ca-get-changed-files/scripts/_libs/filter.lib.sh
+++ b/.github/actions/ca-get-changed-files/scripts/_libs/filter.lib.sh
@@ -29,8 +29,15 @@ resolve_sha_for_event() {
       return 1
     fi
     printf '%s\n%s\n' "$GITHUB_BASE_SHA" "$GITHUB_HEAD_SHA"
+  elif [[ "$_event_name" == "push" ]]; then
+    if [[ -z "${GITHUB_BEFORE_SHA:-}" ]] || [[ -z "${GITHUB_AFTER_SHA:-}" ]]; then
+      echo "::error::push event requires GITHUB_BEFORE_SHA and GITHUB_AFTER_SHA" >&2
+      return 1
+    fi
+    printf '%s\n%s\n' "$GITHUB_BEFORE_SHA" "$GITHUB_AFTER_SHA"
   else
-    printf '%s\n%s\n' "$_before_sha" "$_after_sha"
+    echo "::error::Unsupported event: $_event_name. Use before-sha and after-sha inputs explicitly." >&2
+    return 1
   fi
 }
 


### PR DESCRIPTION
## Overview

**Summary**
Adds push event support to `resolve_sha_for_event` and rejects unsupported events with an explicit error.

**Background / Motivation**
`ca-get-changed-files` action did not handle the `push` event. The `resolve_sha_for_event` function silently returned the raw arguments for any unrecognized event, which caused incorrect SHA resolution on push. This fix adds proper push event handling via `GITHUB_BEFORE_SHA` / `GITHUB_AFTER_SHA` env vars and makes unsupported events fail fast.

## Changes

### Core Changes

- `action.yml`: expose `GITHUB_BEFORE_SHA: ${{ github.event.before }}` and `GITHUB_AFTER_SHA: ${{ github.sha }}` as step env vars
- `filter.lib.sh`: add `push` branch to `resolve_sha_for_event`; return error when env vars are missing; reject unsupported events with `Unsupported event` error and exit 1

### Test Updates

- `filter.unit.spec.sh`: add 4 test cases for push event SHA resolution
  - `T-rsv-edg-02`: unsupported event (`workflow_dispatch`) returns error
  - `T-rsv-psh-01`: push with both env vars set returns two SHAs
  - `T-rsv-psh-02`: push with empty `GITHUB_BEFORE_SHA` returns error
  - `T-rsv-psh-03`: push with empty `GITHUB_AFTER_SHA` returns error

### Removed

N/A

## Change Type (optional)

- [x] Bug fix

## Related Issues

> N/A

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

**Breaking change**: `resolve_sha_for_event` now returns an error for events other than `pull_request` and `push`. Previously it silently passed through the raw SHA arguments.
